### PR TITLE
Removed delimiter in load_csv methods

### DIFF
--- a/dislib/data/base.py
+++ b/dislib/data/base.py
@@ -90,7 +90,7 @@ def load_libsvm_files(path, n_features, store_sparse=True):
                        n_features=n_features)
 
 
-def load_csv_file(path, subset_size, n_features, delimiter=",", label_col=None):
+def load_csv_file(path, subset_size, n_features, label_col=None):
     """ Loads a CSV file into a Dataset.
 
      Parameters
@@ -101,8 +101,6 @@ def load_csv_file(path, subset_size, n_features, delimiter=",", label_col=None):
         Subset size in lines.
     n_features : int
         Number of features.
-    delimiter : string, optional (default ",")
-        String that separates features in the file.
     label_col : int, optional (default=None)
         Column representing data labels. Can be 'first' or 'last'.
 
@@ -113,10 +111,10 @@ def load_csv_file(path, subset_size, n_features, delimiter=",", label_col=None):
         subset_size.
     """
     return _load_file(path, subset_size, fmt="csv", n_features=n_features,
-                      delimiter=delimiter, label_col=label_col)
+                      delimiter=",", label_col=label_col)
 
 
-def load_csv_files(path, n_features, delimiter=",", label_col=None):
+def load_csv_files(path, n_features, label_col=None):
     """ Loads a set of CSV files into a Dataset.
 
     Parameters
@@ -125,8 +123,6 @@ def load_csv_files(path, n_features, delimiter=",", label_col=None):
         Path to a directory containing CSV files.
     n_features : int
         Number of features.
-    delimiter : string, optional (default ",")
-        String that separates features in the file.
     label_col : int, optional (default=None)
         Column representing data labels. Can be 'first' or 'last'.
 
@@ -138,7 +134,7 @@ def load_csv_files(path, n_features, delimiter=",", label_col=None):
    """
 
     return _load_files(path, fmt="csv", n_features=n_features,
-                       delimiter=delimiter, label_col=label_col)
+                       delimiter=",", label_col=label_col)
 
 
 def _load_file(path, part_size, fmt, n_features, delimiter=",",


### PR DESCRIPTION
Removed delimiter in load_csv methods because PyCOMPSs does not support single character parameters (#15 )

Default delimiter is ","