### PR TITLE
Git Ignore '.log' files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ dkms.conf
 # Fortran module files
 *.mod
 *.smod
+
+# Ignore log files
+*.log
+


### PR DESCRIPTION
Log files must be ignored by git. So far, only tests generate 'output.log', but still.