### PR TITLE
Csvm gamma

### DIFF
--- a/dislib/classification/csvm/base.py
+++ b/dislib/classification/csvm/base.py
@@ -28,9 +28,10 @@ class CascadeSVM(object):
         kernels are 'linear' and 'rbf'.
     c : float, optional (default=1.0)
         Penalty parameter C of the error term.
-    gamma : float, optional (default='scale')
-        Supports 'scale' for 1 / (n_features * samples.std()) and 'auto' for
-        1 / (n_features)
+    gamma : float, optional (default='auto')
+        Kernel coefficient for 'rbf'.
+
+        Default is 'auto', which uses 1 / (n_features).
     check_convergence : boolean, optional (default=True)
         Whether to test for convergence. If False, the algorithm will run
         for cascade_iterations. Checking for convergence adds a
@@ -66,6 +67,20 @@ class CascadeSVM(object):
     score(dataset)
         Returns the mean accuracy on the given test dataset.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> x = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
+    >>> y = np.array([1, 1, 2, 2])
+    >>> from dislib.data import load_data
+    >>> train_data = load_data(x=x, y=y, subset_size=4)
+    >>> from dislib.classification import CascadeSVM
+    >>> svm = CascadeSVM()
+    >>> svm.fit(train_data) #doctest: +NORMALIZE_WHITESPACE
+    >>> test_data = load_data(x=np.array([[-0.8, -1]]), subset_size=1)
+    >>> svm.predict(test_data)
+    >>> print(test_data.labels)
+
     References
     ----------
 
@@ -76,10 +91,10 @@ class CascadeSVM(object):
     _name_to_kernel = {"linear": "_linear_kernel", "rbf": "_rbf_kernel"}
 
     def __init__(self, cascade_arity=2, max_iter=5, tol=10 ** -3,
-                 kernel="rbf", c=1, gamma='scale', check_convergence=True,
+                 kernel="rbf", c=1, gamma='auto', check_convergence=True,
                  random_state=None, verbose=False):
 
-        assert (gamma is "auto" or gamma is "scale" or type(gamma) == float
+        assert (gamma is "auto" or type(gamma) == float
                 or type(float(gamma)) == float), "Invalid gamma"
         assert (kernel is None or kernel in self._name_to_kernel.keys()), \
             "Incorrect kernel value [%s], available kernels are %s" % (
@@ -101,6 +116,7 @@ class CascadeSVM(object):
         self._check_convergence = check_convergence
         self._random_state = random_state
         self._verbose = verbose
+        self._gamma = gamma
 
         if kernel == "rbf":
             self._clf_params = {"kernel": kernel, "C": c, "gamma": gamma}
@@ -121,6 +137,7 @@ class CascadeSVM(object):
             Training data.
         """
         self._reset_model()
+        self._set_gamma(dataset.n_features)
 
         while not self._check_finished():
             self._do_iteration(dataset)
@@ -190,6 +207,11 @@ class CascadeSVM(object):
         self._last_w = None
         self._clf = None
         self._feedback = None
+
+    def _set_gamma(self, n_features):
+        if self._gamma == "auto":
+            self._gamma = 1. / n_features
+            self._clf_params["gamma"] = self._gamma
 
     def _collect_clf(self):
         self._feedback, self._clf = compss_wait_on(self._feedback, self._clf)
@@ -279,7 +301,7 @@ class CascadeSVM(object):
 
     def _rbf_kernel(self, x):
         # Trick: || x - y || ausmultipliziert
-        sigmaq = -1 / (2 * self._clf_params["gamma"])
+        sigmaq = -1 / (2 * self._gamma)
         n = x.shape[0]
         k = x.dot(x.T) / sigmaq
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docker>=3.5.0
 decorator==4.0.11
-scikit-learn==0.19.1
+scikit-learn==0.20.2
 scipy==1.0.0
 numpy==1.15.4
 redis==2.10.6

--- a/tests/test_csvm.py
+++ b/tests/test_csvm.py
@@ -68,6 +68,32 @@ class CSVMTest(unittest.TestCase):
         self.assertFalse(csvm.converged)
         self.assertEqual(csvm.iterations, 1)
 
+    def test_fit_default_gamma(self):
+        """ Tests that the fit method converges when using gamma=auto on a
+        toy dataset """
+        seed = 666
+        file_ = "tests/files/libsvm/2"
+
+        dataset = load_libsvm_file(file_, 10, 780)
+
+        csvm = CascadeSVM(cascade_arity=3, max_iter=5,
+                          tol=1e-4, kernel='linear', c=2,
+                          check_convergence=True,
+                          random_state=seed, verbose=False)
+
+        csvm.fit(dataset)
+
+        self.assertTrue(csvm.converged)
+
+        csvm = CascadeSVM(cascade_arity=3, max_iter=1,
+                          tol=1e-4, kernel='linear', c=2, gamma=0.1,
+                          check_convergence=False,
+                          random_state=seed, verbose=False)
+
+        csvm.fit(dataset)
+        self.assertFalse(csvm.converged)
+        self.assertEqual(csvm.iterations, 1)
+
     def test_predict(self):
         seed = 666
 


### PR DESCRIPTION
Created a simple usage example for C-SVM. 

During the creation of the example, I realized that gamma='scale' was not correctly working because it is not supported in scikit-learn 0.19, and because there was a bug in the method that checks the convergence of the model.

I have updated the requirements to the latest scikit-learn version, and removed gamma='scale' as computing X.std() would be expensive. Instead gamma='auto' is the default value for gamma. I have added a test that checks that gamma='auto' now works properly.