### PR TITLE
rf: fixed predict_proba

### DIFF
--- a/dislib/classification/rf/decision_tree.py
+++ b/dislib/classification/rf/decision_tree.py
@@ -215,7 +215,7 @@ class _Node:
         node_content = self.content
         if isinstance(node_content, _LeafInfo):
             single_pred = node_content.frequencies/node_content.size
-            return np.repeat(single_pred, len(sample), 1)
+            return np.tile(single_pred, (len(sample), 1))
         if isinstance(node_content, _SkTreeWrapper):
             if len(sample) > 0:
                 sk_tree_pred = node_content.sk_tree.predict_proba(sample)
@@ -224,9 +224,9 @@ class _Node:
                 return pred
         if isinstance(node_content, _InnerNodeInfo):
             pred = np.empty((len(sample), n_classes), dtype=np.int64)
-            left_mask = sample[:, node_content.index] <= node_content.value
-            pred[left_mask] = self.left.predict_proba(sample[left_mask])
-            pred[~left_mask] = self.right.predict_proba(sample[~left_mask])
+            l_msk = sample[:, node_content.index] <= node_content.value
+            pred[l_msk] = self.left.predict_proba(sample[l_msk], n_classes)
+            pred[~l_msk] = self.right.predict_proba(sample[~l_msk], n_classes)
             return pred
         assert len(sample) == 0, 'Type not supported'
         return np.empty((0, n_classes), dtype=np.int64)

--- a/dislib/classification/rf/decision_tree.py
+++ b/dislib/classification/rf/decision_tree.py
@@ -63,11 +63,12 @@ class DecisionTreeClassifier:
 
     """
 
-    def __init__(self, try_features, max_depth, distr_depth, bootstrap,
-                 random_state):
+    def __init__(self, try_features, max_depth, distr_depth, sklearn_max,
+                 bootstrap, random_state):
         self.try_features = try_features
         self.max_depth = max_depth
         self.distr_depth = distr_depth
+        self.sklearn_max = sklearn_max
         self.bootstrap = bootstrap
         self.random_state = random_state
 
@@ -126,6 +127,7 @@ class DecisionTreeClassifier:
                                                  self.max_depth - depth,
                                                  self.n_classes,
                                                  self.try_features,
+                                                 self.sklearn_max,
                                                  self.random_state,
                                                  samples_path, features_path)
                 node.content = len(self.subtrees)
@@ -283,21 +285,6 @@ def _feature_selection(untried_indices, m_try, random_state):
                                replace=False)
 
 
-@task(returns=tuple)
-def _test_splits(sample, y_s, n_classes, feature_indices, *features):
-    min_score = float_info.max
-    b_value = None
-    b_index = None
-    for t in range(len(feature_indices)):
-        feature = features[t]
-        score, value = test_split(sample, y_s, feature, n_classes)
-        if score < min_score:
-            min_score = score
-            b_index = feature_indices[t]
-            b_value = value
-    return min_score, b_value, b_index
-
-
 def _get_groups(sample, y_s, features_mmap, index, value):
     if index is None:
         empty_sample = np.array([], dtype=np.int64)
@@ -386,39 +373,41 @@ def _compute_split(sample, n_features, y_s, n_classes, m_try, features_mmap,
 
 
 def _build_subtree_wrapper(sample, y_s, n_features, max_depth, n_classes,
-                           m_try, random_state, samples_file, features_file):
+                           m_try, sklearn_max, random_state, samples_file,
+                           features_file):
     seed = random_state.randint(np.iinfo(np.int32).max)
     if features_file is not None:
         return _build_subtree_using_features(sample, y_s, n_features,
-                                             max_depth, n_classes, m_try, seed,
-                                             samples_file, features_file)
+                                             max_depth, n_classes, m_try,
+                                             sklearn_max, seed, samples_file,
+                                             features_file)
     else:
         return _build_subtree(sample, y_s, n_features, max_depth, n_classes,
-                              m_try, seed, samples_file)
+                              m_try, sklearn_max, seed, samples_file)
 
 
 @task(samples_file=FILE_IN, features_file=FILE_IN, returns=_Node)
 def _build_subtree_using_features(sample, y_s, n_features, max_depth,
-                                  n_classes, m_try, seed, samples_file,
-                                  features_file):
+                                  n_classes, m_try, sklearn_max, seed,
+                                  samples_file, features_file):
     random_state = RandomState(seed)
     return _compute_build_subtree(sample, y_s, n_features, max_depth,
-                                  n_classes, m_try, random_state, samples_file,
-                                  features_file=features_file)
+                                  n_classes, m_try, sklearn_max, random_state,
+                                  samples_file, features_file=features_file)
 
 
 @task(samples_file=FILE_IN, returns=_Node)
-def _build_subtree(sample, y_s, n_features, max_depth, n_classes, m_try, seed,
-                   samples_file):
+def _build_subtree(sample, y_s, n_features, max_depth, n_classes, m_try,
+                   sklearn_max, seed, samples_file):
     random_state = RandomState(seed)
     return _compute_build_subtree(sample, y_s, n_features, max_depth,
-                                  n_classes, m_try, random_state, samples_file)
+                                  n_classes, m_try, sklearn_max, random_state,
+                                  samples_file)
 
 
 def _compute_build_subtree(sample, y_s, n_features, max_depth, n_classes,
-                           m_try, random_state, samples_file,
-                           features_file=None, use_sklearn=True,
-                           sklearn_max=1e8):
+                           m_try, sklearn_max, random_state, samples_file,
+                           features_file=None, use_sklearn=True):
     if not sample.size:
         return _Node()
     if features_file is not None:

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -10,6 +10,7 @@ import numpy as np
 
 class RFTest(unittest.TestCase):
     def test_make_classification_score(self):
+        """Tests RandomForestClassifier fit and score with default params."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -35,6 +36,7 @@ class RFTest(unittest.TestCase):
         self.assertGreater(accuracy, 0.7)
 
     def test_make_classification_predict_and_distr_depth(self):
+        """Tests RandomForestClassifier fit and predict with a distr_depth."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -61,6 +63,7 @@ class RFTest(unittest.TestCase):
         self.assertGreater(accuracy, 0.7)
 
     def test_make_classification_fit_predict(self):
+        """Tests RandomForestClassifier fit_predict with default params."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -83,6 +86,7 @@ class RFTest(unittest.TestCase):
         self.assertGreater(accuracy, 0.7)
 
     def test_make_classification_sklearn_max_predict(self):
+        """Tests RandomForestClassifier predict with sklearn_max."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -109,6 +113,7 @@ class RFTest(unittest.TestCase):
         self.assertGreater(accuracy, 0.7)
 
     def test_make_classification_sklearn_max_predict_proba(self):
+        """Tests RandomForestClassifier predict_proba with sklearn_max."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -137,6 +142,7 @@ class RFTest(unittest.TestCase):
         self.assertGreater(accuracy, 0.7)
 
     def test_make_classification_hard_vote_predict(self):
+        """Tests RandomForestClassifier predict with hard_vote."""
         x, y = make_classification(
             n_samples=3000,
             n_features=10,
@@ -161,6 +167,35 @@ class RFTest(unittest.TestCase):
         rf.fit(train_ds)
         rf.predict(test_ds)
         accuracy = np.count_nonzero(test_ds.labels == y_test) / len(y_test)
+        self.assertGreater(accuracy, 0.7)
+
+    def test_make_classification_hard_vote_score_mix(self):
+        """Tests RandomForestClassifier score with hard_vote, sklearn_max,
+        distr_depth and max_depth."""
+        x, y = make_classification(
+            n_samples=3000,
+            n_features=10,
+            n_classes=3,
+            n_informative=4,
+            n_redundant=2,
+            n_repeated=1,
+            n_clusters_per_class=2,
+            shuffle=True,
+            random_state=0)
+        x_train = x[:len(x) // 2]
+        y_train = y[:len(y) // 2]
+        x_test = x[len(x) // 2:]
+        y_test = y[len(y) // 2:]
+
+        train_ds = load_data(x=x_train, y=y_train, subset_size=300)
+        test_ds = load_data(x=x_test, y=y_test, subset_size=300)
+
+        rf = RandomForestClassifier(random_state=0, sklearn_max=100,
+                                    distr_depth=2, max_depth=12,
+                                    hard_vote=True)
+
+        rf.fit(train_ds)
+        accuracy = rf.score(test_ds)
         self.assertGreater(accuracy, 0.7)
 
 

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -1,5 +1,6 @@
 import unittest
 
+from pycompss.api.api import compss_wait_on
 from sklearn.datasets import make_classification
 
 from dislib.classification import RandomForestClassifier
@@ -79,6 +80,87 @@ class RFTest(unittest.TestCase):
 
         rf.fit_predict(train_ds)
         accuracy = np.count_nonzero(train_ds.labels == y_train) / len(y_train)
+        self.assertGreater(accuracy, 0.7)
+
+    def test_make_classification_sklearn_max_predict(self):
+        x, y = make_classification(
+            n_samples=3000,
+            n_features=10,
+            n_classes=3,
+            n_informative=4,
+            n_redundant=2,
+            n_repeated=1,
+            n_clusters_per_class=2,
+            shuffle=True,
+            random_state=0)
+        x_train = x[:len(x) // 2]
+        y_train = y[:len(y) // 2]
+        x_test = x[len(x) // 2:]
+        y_test = y[len(y) // 2:]
+
+        train_ds = load_data(x=x_train, y=y_train, subset_size=300)
+        test_ds = load_data(x=x_test, subset_size=300)
+
+        rf = RandomForestClassifier(random_state=0, sklearn_max=10)
+
+        rf.fit(train_ds)
+        rf.predict(test_ds)
+        accuracy = np.count_nonzero(test_ds.labels == y_test) / len(y_test)
+        self.assertGreater(accuracy, 0.7)
+
+    def test_make_classification_sklearn_max_predict_proba(self):
+        x, y = make_classification(
+            n_samples=3000,
+            n_features=10,
+            n_classes=3,
+            n_informative=4,
+            n_redundant=2,
+            n_repeated=1,
+            n_clusters_per_class=2,
+            shuffle=True,
+            random_state=0)
+        x_train = x[:len(x) // 2]
+        y_train = y[:len(y) // 2]
+        x_test = x[len(x) // 2:]
+        y_test = y[len(y) // 2:]
+
+        train_ds = load_data(x=x_train, y=y_train, subset_size=300)
+        test_ds = load_data(x=x_test, subset_size=300)
+
+        rf = RandomForestClassifier(random_state=0, sklearn_max=10)
+
+        rf.fit(train_ds)
+        rf.predict_proba(test_ds)
+        rf.classes = compss_wait_on(rf.classes)
+        y_pred = rf.classes[np.argmax(test_ds.labels, axis=1)]
+        accuracy = np.count_nonzero(y_pred == y_test) / len(y_test)
+        self.assertGreater(accuracy, 0.7)
+
+    def test_make_classification_hard_vote_predict(self):
+        x, y = make_classification(
+            n_samples=3000,
+            n_features=10,
+            n_classes=3,
+            n_informative=4,
+            n_redundant=2,
+            n_repeated=1,
+            n_clusters_per_class=2,
+            shuffle=True,
+            random_state=0)
+        x_train = x[:len(x) // 2]
+        y_train = y[:len(y) // 2]
+        x_test = x[len(x) // 2:]
+        y_test = y[len(y) // 2:]
+
+        train_ds = load_data(x=x_train, y=y_train, subset_size=300)
+        test_ds = load_data(x=x_test, subset_size=300)
+
+        rf = RandomForestClassifier(random_state=0, sklearn_max=10,
+                                    hard_vote=True)
+
+        rf.fit(train_ds)
+        rf.predict(test_ds)
+        accuracy = np.count_nonzero(test_ds.labels == y_test) / len(y_test)
         self.assertGreater(accuracy, 0.7)
 
 


### PR DESCRIPTION
# Description

Decision tree predict_proba was not working if while building it the `use_sklearn and n_features * len(sample) <= sklearn_max` of the _compute_build_subtree method was False. In this conditions, _InnerNodeInfo and _LeafInfo objects appear and the _Node.predict_proba() wasn't working for these objects. This has been fixed now.

Fixes #114

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. If you haven't added any test and it is relevant provide instructions so we can reproduce.

- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.

Reproduce instructions:

Use a very big dataset or manually set `sklearn_max=10`, and call rf.predict_proba(dataset).


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented the public methods of any public class according to the guide styles. 
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
