### PR TITLE
rf_iris example small fixes

### DIFF
--- a/examples/rf_iris.py
+++ b/examples/rf_iris.py
@@ -27,21 +27,18 @@ def main():
 
     # Test the trained RF classifier
     print("- Testing the classifier.", end='')
-    test_ds = load_data(x[test_idx], 10, y[test_idx])
+    test_ds = load_data(x[test_idx], 10)
     forest.predict(test_ds)
-    test_ds.collect()
+    y_pred = test_ds.labels
 
-    labels = []
-    for subset in test_ds:
-        labels.append(subset.labels)
-    y_pred = np.concatenate(labels)
+    test_ds = load_data(x[test_idx], 10, y[test_idx])
+    score = forest.score(test_ds)
 
     # Put results in fancy dataframe and print the accuracy
     df = pd.DataFrame(data=list(zip(y[test_idx], y_pred)),
                       columns=['Label', 'Predicted'])
     print(" Predicted values: \n\n%s" % df)
-    print("test_ds %s" % test_ds)
-    print("\n- Classifier accuracy: %s" % forest.score(test_ds))
+    print("\n- Classifier accuracy: %s" % score)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

rf_iris.py used a rf.preict(dataset) an then used the same dataset for rf.score(dataset), but the labels of the original dataset ('true' labels) which score() needs had been changed by predict(). This has been fixed reloaing the dataset. Also, dataset.labels property is used to simplify the code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I have tested it manually in a **local environment**.

Reproduce instructions:
runcompss --python_interpreter=python3 ./examples/rf_iris.py

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
