### PR TITLE
Adapt GaussianMixture to sparse data

### DIFF
--- a/tests/test_gm.py
+++ b/tests/test_gm.py
@@ -6,12 +6,13 @@ from pycompss.api.api import compss_wait_on
 from sklearn.datasets import make_blobs
 
 from dislib.cluster import GaussianMixture
-from dislib.data import Dataset
+from dislib.data import Dataset, load_libsvm_file
 from dislib.data import Subset
 from dislib.data import load_data
 
 
 class GaussianMixtureTest(unittest.TestCase):
+
     def test_init_params(self):
         """Tests that GaussianMixture params are set"""
         n_components = 2
@@ -151,6 +152,19 @@ class GaussianMixtureTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             gm = GaussianMixture(covariance_type='')
             gm.fit(dataset)
+
+    def test_sparse(self):
+        """ Tests GaussianMixture produces the same results using dense and
+        sparse data structures. """
+        file_ = "tests/files/libsvm/2"
+
+        sparse = load_libsvm_file(file_, 10, 780)
+        dense = load_libsvm_file(file_, 10, 780, store_sparse=False)
+
+        gm = GaussianMixture(n_components=4, random_state=170)
+        gm.fit_predict(sparse)
+        gm.fit_predict(dense)
+        self.assertTrue(np.array_equal(sparse.labels, dense.labels))
 
 
 def main():

--- a/tests/test_gm.py
+++ b/tests/test_gm.py
@@ -166,6 +166,16 @@ class GaussianMixtureTest(unittest.TestCase):
         gm.fit_predict(dense)
         self.assertTrue(np.array_equal(sparse.labels, dense.labels))
 
+    def test_init_random(self):
+        """ Tests GaussianMixture random initialization."""
+        np.random.seed(0)
+        x = np.random.rand(50, 3)
+        dataset = load_data(x, subset_size=10)
+        gm = GaussianMixture(init_params='random', n_components=4,
+                             random_state=170)
+        gm.fit(dataset)
+        self.assertGreater(gm.n_iter, 5)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
# Description

Added a sparse data test, equivalent to the one in KMeans, to GaussianMixture. Adapted GaussianMixture module to support sparse data. Now it works using csr_matrix for Subset.samples.

Fixes #136

## Type of change

Please delete options that are not relevant.

- [ ] New algorithm or support class.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. If you haven't added any test and it is relevant provide instructions so we can reproduce.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions: see GaussianMixtureTest.test_sparse

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have documented the public methods of any public class according to the guide styles. 
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
