### PR TITLE
Gaussian mixture: added covariance types 'tied', 'diag' and 'spherical', and extra tests

### DIFF
--- a/dislib/cluster/gm/base.py
+++ b/dislib/cluster/gm/base.py
@@ -66,6 +66,11 @@ def _estimate_covariances(dataset, resp, nk, means, reg_covar, covar_type,
         The input data.
     resp : array-like, shape (n_samples, n_components)
         The responsibilities for each data sample in X.
+    nk : array-like, shape (n_components,)
+        The numbers of data samples (weighted by responsibility) in the
+        current components.
+    means : array-like, shape (n_components, n_features)
+        The centers of the current components.
     reg_covar : float
         The regularization added to the diagonal of the covariance matrices.
     covar_type : {'full', 'tied', 'diag', 'spherical'}
@@ -239,9 +244,15 @@ def _compute_precision_cholesky(covariances, covariance_type):
 
 
 @task(returns=1)
-def _merge_log_prob_norm(*partials):
+def _sum_log_prob_norm(*partials):
     total, count = map(sum, zip(*partials))
     return total, count
+
+
+@task(returns=1)
+def _finalize_sum_log_prob_norm(*partials):
+    total, count = map(sum, zip(*partials))
+    return total / count
 
 
 @task(returns=2)
@@ -256,6 +267,8 @@ def _estimate_responsibilities(subset, weights, means, precisions_cholesky,
     Parameters
     ----------
     subset : dislib.datat.Subset
+    weights : array-like, shape (n_components,)
+        The weights of the current components.
     means : array-like, shape (n_components, n_features)
         The centers of the current components.
     precisions_cholesky : array-like
@@ -420,7 +433,7 @@ class GaussianMixture:
     """Gaussian mixture model.
 
     Estimates the parameters of a Gaussian mixture model probability function
-    that fits the data. Allows clustering and density estimation.
+    that fits the data. Allows clustering.
 
     Parameters
     ----------
@@ -434,9 +447,14 @@ class GaussianMixture:
             'tied' (all components share the same general covariance matrix),
             'diag' (each component has its own diagonal covariance matrix),
             'spherical' (each component has its own single variance).
+    check_convergence : boolean, optional (default=True)
+        Whether to test for convergence at the end of each iteration. Setting
+        it to False removes control dependencies, allowing fitting this model
+        in parallel with other tasks.
     tol : float, defaults to 1e-3.
-        The convergence threshold. EM iterations will stop when the
-        lower bound average gain is below this threshold.
+        The convergence threshold. If the absolute change of the lower bound
+        respect to the previous iteration is below this threshold, the
+        iterations will stop. Ignored if `check_convergence` is False.
     reg_covar : float, defaults to 1e-6.
         Non-negative regularization added to the diagonal of covariance.
         Allows to assure that the covariance matrices are all positive.
@@ -444,21 +462,23 @@ class GaussianMixture:
         The number of EM iterations to perform.
     init_params : {'kmeans', 'random'}, defaults to 'kmeans'.
         The method used to initialize the weights, the means and the
-        precisions.
+        precisions. This method defines the responsibilities and a maximization
+        step gives the model parameters. This is not used if `weights_init`,
+        `means_init` and `precisions_init` are all provided.
         Must be one of::
 
-            'kmeans' : responsibilities are initialized using kmeans.
+            'kmeans' : responsibilities are initialized using kmeans,
             'random' : responsibilities are initialized randomly.
     weights_init : array-like, shape (n_components, ), optional
         The user-provided initial weights, defaults to None.
-        If it None, weights are initialized using the `init_params` method.
+        If None, weights are initialized using the `init_params` method.
     means_init : array-like, shape (n_components, n_features), optional
-        The user-provided initial means, defaults to None,
-        If it None, means are initialized using the `init_params` method.
+        The user-provided initial means, defaults to None.
+        If None, means are initialized using the `init_params` method.
     precisions_init : array-like, optional.
         The user-provided initial precisions (inverse of the covariance
         matrices), defaults to None.
-        If it None, precisions are initialized using the 'init_params' method.
+        If None, precisions are initialized using the `init_params` method.
         The shape depends on 'covariance_type'::
 
             (n_components,)                        if 'spherical',
@@ -478,7 +498,7 @@ class GaussianMixture:
     Attributes
     ----------
     weights_ : array-like, shape (n_components,)
-        The weights of each mixture components.
+        The weight of each mixture component.
     means_ : array-like, shape (n_components, n_features)
         The mean of each mixture component.
     covariances_ : array-like
@@ -503,7 +523,8 @@ class GaussianMixture:
             (n_components, n_features)             if 'diag',
             (n_components, n_features, n_features) if 'full'
     converged_ : bool
-        True if convergence is reached, False otherwise.
+        True if `check_convergence` is True and convergence is reached, False
+        otherwise.
     n_iter : int
         Number of EM iterations done.
     lower_bound_ : float
@@ -527,12 +548,15 @@ class GaussianMixture:
     >>> print(compss_wait_on(gm.means_))
     """
 
-    def __init__(self, n_components=1, covariance_type='full', tol=1e-3,
-                 reg_covar=1e-6, max_iter=100, init_params='kmeans',
-                 weights_init=None, means_init=None, precisions_init=None,
-                 arity=50, verbose=False, random_state=None):
+    def __init__(self, n_components=1, covariance_type='full',
+                 check_convergence=True, tol=1e-3, reg_covar=1e-6,
+                 max_iter=100, init_params='kmeans', weights_init=None,
+                 means_init=None, precisions_init=None, arity=50,
+                 verbose=False, random_state=None):
 
         self.n_components = n_components
+        self._check_convergence = check_convergence
+        self.covariance_type = covariance_type
         self.tol = tol
         self.reg_covar = reg_covar
         self.max_iter = max_iter
@@ -540,7 +564,6 @@ class GaussianMixture:
         self._arity = arity
         self._verbose = verbose
         self.random_state = random_state
-        self.covariance_type = covariance_type
         self.weights_init = weights_init
         self.means_init = means_init
         self.precisions_init = precisions_init
@@ -548,14 +571,20 @@ class GaussianMixture:
     def fit(self, dataset):
         """Estimate model parameters with the EM algorithm.
 
-        The method iterates between E-step and M-step for ``max_iter``
-        times until the change of likelihood or lower bound is less than
-        ``tol``, otherwise, a ``ConvergenceWarning`` is raised.
+        Iterates between E-steps and M-steps until convergence or until
+        `max_iter` iterations are reached. It estimates the model parameters
+        `weights_`, `means_` and `covariances_`.
 
         Parameters
         ----------
         dataset : dislib.data.Dataset
             Data points.
+
+        Warns
+        -----
+        ConvergenceWarning
+            If `tol` is not None and `max_iter` iterations are reached without
+            convergence.
         """
         self._check_initial_parameters()
 
@@ -571,24 +600,24 @@ class GaussianMixture:
         for self.n_iter in range(1, self.max_iter + 1):
             prev_lower_bound = self.lower_bound_
 
-            log_prob_norm, resp = self._e_step(dataset)
+            self.lower_bound_, resp = self._e_step(dataset)
             self._m_step(dataset, resp)
             for resp_subset in resp:
                 compss_delete_object(resp_subset)
-            log_prob_total, log_prob_count = compss_wait_on(log_prob_norm)
-            self.lower_bound_ = log_prob_total / log_prob_count
 
-            diff = abs(self.lower_bound_ - prev_lower_bound)
+            if self._check_convergence:
+                self.lower_bound_ = compss_wait_on(self.lower_bound_)
+                diff = abs(self.lower_bound_ - prev_lower_bound)
 
-            if self._verbose:
-                iter_msg_template = "Iteration %s - Convergence crit. = %s"
-                print(iter_msg_template % (self.n_iter, diff))
+                if self._verbose:
+                    iter_msg_template = "Iteration %s - Convergence crit. = %s"
+                    print(iter_msg_template % (self.n_iter, diff))
 
-            if diff < self.tol:
-                self.converged_ = True
-                break
+                if diff < self.tol:
+                    self.converged_ = True
+                    break
 
-        if not self.converged_:
+        if self._check_convergence and not self.converged_:
             warnings.warn('The algorithm did not converge. '
                           'Try different init parameters, '
                           'or increase max_iter, tol '
@@ -598,15 +627,19 @@ class GaussianMixture:
     def fit_predict(self, dataset):
         """Estimate model parameters and predict labels of the same dataset.
 
-        The method iterates between E-step and M-step for `max_iter`
-        times until the change of likelihood or lower bound is less than
-        `tol`, otherwise, a `ConvergenceWarning` is raised. After fitting, it
-        predicts the most probable label for the input dataset.
+        Fits the model and, after fitting, uses the model to predict labels for
+        the same training dataset.
 
         Parameters
         ----------
         dataset : dislib.data.Dataset
             Data points.
+
+        Warns
+        -----
+        ConvergenceWarning
+            If `tol` is not None and `max_iter` iterations are reached without
+            convergence.
         """
         self.fit(dataset)
         self.predict(dataset)
@@ -640,8 +673,8 @@ class GaussianMixture:
             dataset.
 
         responsibility : dislib.data.Dataset
-            Posterior probabilities (or responsibilities) of
-            the point of each sample in X.
+            Posterior probabilities (or responsibilities) of each sample in the
+            dataset.
         """
         log_prob_norm = []
         resp = Dataset(self.n_components)
@@ -675,11 +708,11 @@ class GaussianMixture:
                                           self.covariance_type)
 
     def _reduce_log_prob_norm(self, partials):
-        while len(partials) > 1:
+        while len(partials) > self._arity:
             partials_subset = partials[:self._arity]
             partials = partials[self._arity:]
-            partials.append(_merge_log_prob_norm(*partials_subset))
-        return partials[0]
+            partials.append(_sum_log_prob_norm(*partials_subset))
+        return _finalize_sum_log_prob_norm(*partials)
 
     def _m_step(self, dataset, resp):
         """M step.
@@ -718,7 +751,8 @@ class GaussianMixture:
         weights : array-like, shape (n_components,)
             The weights of the current components.
         nk : array-like, shape (n_components,)
-            The numbers of data samples in the current components.
+            The numbers of data samples (weighted by responsibility) in the
+            current components.
         means : array-like, shape (n_components, n_features)
             The centers of the current components.
         """
@@ -757,6 +791,70 @@ class GaussianMixture:
                              "['spherical', 'tied', 'diag', 'full']"
                              % self.covariance_type)
 
+        self._prepare_init_parameters()
+        n = self.n_components
+        if self.weights_init is not None:
+            shape = self.weights_init.shape
+            if shape != (n,):
+                raise ValueError("n_components=%d, " % n +
+                                 "weights_init.shape=%s, " % str(shape) +
+                                 "weights_init.shape should be "
+                                 "(n_components,)")
+        if self.means_init is not None:
+            shape = self.means_init.shape
+            if len(shape) != 2 or shape[0] != n:
+                raise ValueError("n_components=%d, " % n +
+                                 "means_init.shape=%s, " % str(shape) +
+                                 "means_init.shape should be "
+                                 "(n_components, n_features)")
+        if self.precisions_init is not None:
+            shape = self.precisions_init.shape
+            cov_type = self.covariance_type
+            if cov_type == 'spherical':
+                if shape != (n,):
+                    raise ValueError("n_components=%d, " % n +
+                                     "precisions_init.shape=%s, " % str(shape)
+                                     +
+                                     "precisions_init.shape should be "
+                                     "(n_components,) for "
+                                     "covariance_type='spherical'")
+            elif cov_type == 'tied':
+                if len(shape) != 2 or shape[0] != shape[1]:
+                    raise ValueError("precisions_init.shape=%s, " % str(shape)
+                                     +
+                                     "precisions_init.shape should be "
+                                     "(n_features, n_features) for "
+                                     "covariance_type='tied'")
+            elif cov_type == 'diag':
+                if len(shape) != 2 or shape[0] != n:
+                    raise ValueError("n_components=%d, " % n +
+                                     "precisions_init.shape=%s, " % str(shape)
+                                     +
+                                     "precisions_init.shape should be "
+                                     "(n_components, n_features) for "
+                                     "covariance_type='diag'")
+            elif cov_type == 'full':
+                if len(shape) != 3 or shape[0] != n or shape[1] != shape[2]:
+                    raise ValueError("n_components=%d, " % n +
+                                     "precisions_init.shape=%s, " % str(shape)
+                                     +
+                                     "precisions_init.shape should be "
+                                     "(n_components, n_features, n_features) "
+                                     "for covariance_type='full'")
+        if self.means_init is not None and self.precisions_init is not None:
+            if self.covariance_type in ('tied', 'diag', 'full'):
+                if self.means_init.shape[1] != self.precisions_init.shape[1]:
+                    raise ValueError("n_features mismatch in the dimensions "
+                                     "of 'means_init' and 'precisions_init'")
+
+    def _prepare_init_parameters(self):
+        if isinstance(self.weights_init, (list, tuple)):
+            self.weights_init = np.array(self.weights_init)
+        if isinstance(self.means_init, (list, tuple)):
+            self.means_init = np.array(self.means_init)
+        if isinstance(self.precisions_init, (list, tuple)):
+            self.precisions_init = np.array(self.precisions_init)
+
     def _initialize_parameters(self, dataset, random_state):
         """Initialization of the Gaussian mixture parameters.
 
@@ -767,54 +865,64 @@ class GaussianMixture:
         random_state : RandomState
             A random number generator instance.
         """
-        n_components = self.n_components
-        resp = Dataset(n_components)
-        if self.init_params == 'kmeans':
-            if self._verbose:
-                print("KMeans initialization start")
-            seed = random_state.randint(0, int(1e8))
-            kmeans = KMeans(n_clusters=n_components, random_state=seed,
-                            verbose=self._verbose)
-            kmeans.fit_predict(dataset)
-            self.kmeans = kmeans
-            for labeled_subset in dataset:
-                resp.append(_resp_subset(labeled_subset, n_components))
-        elif self.init_params == 'random':
-            chunks = len(dataset)
-            seeds = random_state.randint(np.iinfo(np.int32).max, size=chunks)
-            for i in range(chunks):
-                subset = dataset[i]
-                resp.append(_random_resp_subset(subset, n_components,
-                                                seeds[i]))
-        else:
-            raise ValueError("Unimplemented initialization method '%s'"
-                             % self.init_params)
+        if self.weights_init is not None:
+            self.weights_ = self.weights_init / np.sum(self.weights_init)
+        if self.means_init is not None:
+            self.means_ = self.means_init
+        if self.precisions_init is not None:
+            if self.covariance_type == 'full':
+                self.precisions_cholesky_ = np.array(
+                    [linalg.cholesky(prec_init, lower=True)
+                     for prec_init in self.precisions_init])
+            elif self.covariance_type == 'tied':
+                self.precisions_cholesky_ = linalg.cholesky(
+                    self.precisions_init, lower=True)
+            else:
+                self.precisions_cholesky_ = self.precisions_init
+        initialize_params = (self.weights_init is None or
+                             self.means_init is None or
+                             self.precisions_init is None)
+        if initialize_params:
+            n_components = self.n_components
+            resp = Dataset(n_components)
+            if self.init_params == 'kmeans':
+                if self._verbose:
+                    print("KMeans initialization start")
+                seed = random_state.randint(0, int(1e8))
+                kmeans = KMeans(n_clusters=n_components, random_state=seed,
+                                verbose=self._verbose)
+                kmeans.fit_predict(dataset)
+                self.kmeans = kmeans
+                for labeled_subset in dataset:
+                    resp.append(_resp_subset(labeled_subset, n_components))
+            elif self.init_params == 'random':
+                chunks = len(dataset)
+                seeds = random_state.randint(np.iinfo(np.int32).max,
+                                             size=chunks)
+                for i in range(chunks):
+                    subset = dataset[i]
+                    resp.append(_random_resp_subset(subset, n_components,
+                                                    seeds[i]))
+            else:
+                raise ValueError("Unimplemented initialization method '%s'"
+                                 % self.init_params)
 
-        weights, nk, means = self._estimate_parameters(dataset, resp)
+            weights, nk, means = self._estimate_parameters(dataset, resp)
+            if self.means_init is None:
+                self.means_ = means
+            if self.weights_init is None:
+                self.weights_ = weights
 
-        self.weights_ = (weights if self.weights_init is None else
-                         self.weights_init)
-        self.means_ = means if self.means_init is None else self.means_init
+            if self.precisions_init is None:
+                cov, p_c = _estimate_covariances(dataset, resp, nk,
+                                                 self.means_, self.reg_covar,
+                                                 self.covariance_type,
+                                                 self._arity)
+                self.covariances_ = cov
+                self.precisions_cholesky_ = p_c
 
-        if self.precisions_init is None:
-            cov, p_c = _estimate_covariances(dataset, resp, nk, means,
-                                             self.reg_covar,
-                                             self.covariance_type,
-                                             self._arity)
-            self.covariances_ = cov
-            self.precisions_cholesky_ = p_c
-        elif self.covariance_type == 'full':
-            self.precisions_cholesky_ = np.array(
-                [linalg.cholesky(prec_init, lower=True)
-                 for prec_init in self.precisions_init])
-        elif self.covariance_type == 'tied':
-            self.precisions_cholesky_ = linalg.cholesky(self.precisions_init,
-                                                        lower=True)
-        else:
-            self.precisions_cholesky_ = self.precisions_init
-
-        for resp_subset in resp:
-            compss_delete_object(resp_subset)
+            for resp_subset in resp:
+                compss_delete_object(resp_subset)
 
 
 @task(returns=1)

--- a/dislib/recommendation/als/base.py
+++ b/dislib/recommendation/als/base.py
@@ -26,8 +26,7 @@ class ALS(object):
     lambda_ : float, optional (default=0.065)
         Regularization parameters value.
     check_convergence : boolean, optional (default=True)
-        Whether to test for convergence for convergence at the end of each
-        iteration.
+        Whether to test for convergence at the end of each iteration.
     random_state : int, orNone, optional (default=None)
         The seed of the pseudo random number generator used to initialize the
         items matrix I.

--- a/docs/source/dislib.rst
+++ b/docs/source/dislib.rst
@@ -9,11 +9,11 @@ Subpackages
     dislib.classification.csvm
     dislib.classification.rf
     dislib.cluster.kmeans
-    dislib.cluster.knn
+    dislib.neighbors
     dislib.cluster.dbscan
     dislib.recommendation.als
     dislib.data
-    dislib.fft
+    dislib.other
 
 .. automodule:: dislib
     :members:

--- a/examples/gm_covariance_types_comp.py
+++ b/examples/gm_covariance_types_comp.py
@@ -1,0 +1,133 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from dislib.cluster import GaussianMixture
+from dislib.data import load_data
+
+
+def main():
+    # Based on tests.test_gm.GaussianMixtureTest.test_covariance_types
+    # Copied code START
+    """ Tests GaussianMixture covariance types """
+    np.random.seed(0)
+    n_samples = 600
+    n_features = 2
+
+    def create_anisotropic_dataset():
+        """Create dataset with 2 anisotropic gaussians of different
+        weight"""
+        n0 = 2 * n_samples // 3
+        n1 = n_samples // 3
+        x0 = np.random.normal(size=(n0, n_features))
+        x1 = np.random.normal(size=(n1, n_features))
+        transformation = [[0.6, -0.6], [-0.4, 0.8]]
+        x0 = np.dot(x0, transformation)
+        x1 = np.dot(x1, transformation) + [0, 3]
+        x = np.concatenate((x0, x1))
+        y = np.concatenate((np.zeros(n0), np.ones(n1)))
+        return x, y
+
+    def create_spherical_blobs_dataset():
+        """Create dataset with 2 spherical gaussians of different weight,
+        variance and position"""
+        n0 = 2 * n_samples // 3
+        n1 = n_samples // 3
+        x0 = np.random.normal(size=(n0, 2), scale=0.5, loc=[2, 0])
+        x1 = np.random.normal(size=(n1, 2), scale=2.5)
+        x = np.concatenate((x0, x1))
+        y = np.concatenate((np.zeros(n0), np.ones(n1)))
+        return x, y
+
+    def create_uncorrelated_dataset():
+        """Create dataset with 2 gaussians forming a cross of uncorrelated
+        variables"""
+        n0 = 2 * n_samples // 3
+        n1 = n_samples // 3
+        x0 = np.random.normal(size=(n0, n_features))
+        x1 = np.random.normal(size=(n1, n_features))
+        x0 = np.dot(x0, [[1.2, 0], [0, 0.5]]) + [0, 3]
+        x1 = np.dot(x1, [[0.4, 0], [0, 2.5]]) + [1, 0]
+        x = np.concatenate((x0, x1))
+        y = np.concatenate((np.zeros(n0), np.ones(n1)))
+        return x, y
+
+    def create_correlated_dataset():
+        """Create dataset with 2 gaussians forming a cross of correlated
+        variables"""
+        x, y = create_uncorrelated_dataset()
+        x = np.dot(x, [[1, 1], [-1, 1]])
+        return x, y
+
+    datasets = {'aniso': create_anisotropic_dataset(),
+                'blobs': create_spherical_blobs_dataset(),
+                'uncorr': create_uncorrelated_dataset(),
+                'corr': create_correlated_dataset()}
+    real_labels = {k: v[1] for k, v in datasets.items()}
+    for k, v in datasets.items():
+        datasets[k] = load_data(x=v[0], subset_size=200)
+
+    covariance_types = 'full', 'tied', 'diag', 'spherical'
+
+    def compute_accuracy(real, predicted):
+        """ Computes classification accuracy for binary (0/1) labels"""
+        equal_labels = np.count_nonzero(predicted == real)
+        equal_ratio = equal_labels / len(real)
+        return max(equal_ratio, 1 - equal_ratio)
+
+    accuracy = {}
+    pred_labels = {}
+    for cov_type in covariance_types:
+        accuracy[cov_type] = {}
+        pred_labels[cov_type] = {}
+        gm = GaussianMixture(n_components=2, covariance_type=cov_type,
+                             random_state=0)
+        for ds in datasets.values():
+            gm.fit_predict(ds)
+        for k, ds in datasets.items():
+            pred = ds.labels
+            pred_labels[cov_type][k] = pred
+            accuracy[cov_type][k] = compute_accuracy(real_labels[k], pred)
+    # Copied code END
+
+    # Plot START
+    plt.figure(figsize=(9 * 2 + 3, 12.5))
+    plt.subplots_adjust(left=.02, right=.98, bottom=.001, top=.96,
+                        wspace=.05,
+                        hspace=.01)
+    plot_num = 1
+
+    for i_ds, (ds_name, ds) in enumerate(datasets.items()):
+        x = ds.samples
+
+        plt.subplot(len(datasets), len(covariance_types) + 1, plot_num)
+        if i_ds == 0:
+            plt.title('original', size=18)
+        colors = np.array(['#377eb8', '#ff7f00'])
+        label_colors = colors[real_labels[ds_name].astype(int)]
+        plt.scatter(x[:, 0], x[:, 1], s=10, color=label_colors)
+        plt.xticks(())
+        plt.yticks(())
+        plot_num += 1
+
+        for cov_type in covariance_types:
+            plt.subplot(len(datasets), len(covariance_types) + 1, plot_num)
+            if i_ds == 0:
+                plt.title(cov_type, size=18)
+
+            colors = np.array(['#377eb8', '#ff7f00'])
+            label_colors = colors[pred_labels[cov_type][ds_name]]
+            plt.scatter(x[:, 0], x[:, 1], s=10, color=label_colors)
+            plt.xticks(())
+            plt.yticks(())
+            plt.text(.99, .01,
+                     ('%.2f' % accuracy[cov_type][ds_name]).lstrip('0'),
+                     transform=plt.gca().transAxes, size=15,
+                     horizontalalignment='right')
+            plot_num += 1
+
+    plt.show()
+    # Plot END
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description
Added support for covariance_type='tied', 'diag', and 'spherical':
- 'tied' (all components share the same general covariance matrix),
- 'diag' (each component has its own diagonal covariance matrix),
- 'spherical' (each component has its own single variance).

With the already supported covariance_type='full', this completes the 4 covariance types present in scikit-learn.

The _test_sparse_ has been expanded to check that the new types work on dense and sparse datasets. A _test_covariance_types_ has been added, which compares the weaker or stronger clustering of the different types on 4 carefully crafted datasets. A graphical plot of this comparison has been added at examples/gm_covariance_types_comparision.py.

Also: improvements of the documentation, increased parameter validation and adaptation, code simplified.

Also new tests have been added to check: 
- verbose mode
- ConvergenceWarning is raised
- fit() and predict() is equivalent to fit_predict()
- execution with weights_init, means_init and precisions_init


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [ ] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have documented the public methods of any public class according to the guide styles. 
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
