### PR TITLE
DBSCAN: radius_neighbors instead of pairwise_distances in partial_dbscan

### DIFF
--- a/dislib/cluster/dbscan/classes.py
+++ b/dislib/cluster/dbscan/classes.py
@@ -143,10 +143,6 @@ def _concatenate_subsets(*subsets):
     return subset
 
 
-def _vec_matrix_euclid(vector, matrix):
-    return np.linalg.norm(vector - matrix, axis=1)
-
-
 @task(returns=1)
 def _lists_to_array(*cp_list):
     return np.concatenate(cp_list)

--- a/examples/dbscan-driver.py
+++ b/examples/dbscan-driver.py
@@ -3,7 +3,7 @@ import os
 import time
 
 import numpy as np
-from pycompss.api.api import barrier
+from pycompss.api.api import compss_barrier
 
 from dislib.cluster import DBSCAN
 from dislib.data import (load_libsvm_file, load_libsvm_files, load_txt_file,
@@ -75,7 +75,7 @@ def main():
                                  n_features=args.features, label_col=label_col)
 
     if args.detailed_times:
-        barrier()
+        compss_barrier()
         read_time = time.time() - s_time
         s_time = time.time()
 
@@ -90,7 +90,7 @@ def main():
                     dimensions=dims, arrange_data=args.arrange)
     dbscan.fit(data)
 
-    barrier()
+    compss_barrier()
     fit_time = time.time() - s_time
 
     out = [dbscan._eps, dbscan._min_samples, dbscan._max_samples,


### PR DESCRIPTION

# Description

In the _compute_neighbours task (inside the partial_dbscan), the neighbors are computed for each sample in the region (in chunks of max_samples elements). This used pairwise_distances, computing the distances to all the points in the same region and neighboring regions. This has been modified to use sklearn.neighbors.NearestNeighbors.radius_neighbors(), avoiding the need to compute all the distances. Performance of this task has improved a lot in a large execution in MN4.
Fixes #193

## Type of change

- [x] Performance improvement.

# How Has This Been Tested?

Run the tests in local and an execution in MN4 before and after.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [x] I have tested it manually in a **supercomputer**.

Reproduce instructions:
IN MN4, with a dislib installation loaded:
`enqueue_compss -t --qos=debug --scheduler=es.bsc.compss.scheduler.fifoDataScheduler.FIFODataScheduler --worker_in_master_cpus=0 --cpus_per_node=30 --worker_working_dir=<gpfs or scratch or COMPSs sandbox path> --exec_time=120 --num_nodes=16 --base_log_dir=<home or projects home path> <dislib path>/dislib/examples/dbscan-driver.py -e 0.19 -m 5 -f 5 -x 5000 -p 10000 -r 17 -d 0,1 --arrange /gpfs/projects/bsc19/COMPSs_DATASETS/dislib/gaia/dbscan/data_scaled.csv`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [NA] I have documented the public methods of any public class according to the guide styles. 
- [NA] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
