### PR TITLE
DBSCAN: bug fixes and performance optimizations

### DIFF
--- a/dislib/cluster/dbscan/base.py
+++ b/dislib/cluster/dbscan/base.py
@@ -159,7 +159,7 @@ class DBSCAN():
 
         for subset_idx, region_id in enumerate(np.ndindex(grid.shape)):
             region = grid[region_id]
-            region.update_labels(n_dims, self._components)
+            region.update_labels(self._components)
             final_labels.append(region.labels)
 
             if not self._arrange_data:
@@ -228,6 +228,12 @@ def _merge_dicts(*dicts):
 
 @task(returns=1)
 def _get_connected_components(equiv):
+
+    # Add inverse equivalences
+    for node, neighs in equiv.items():
+        for neigh in neighs:
+            equiv[neigh].add(node)
+
     visited = set()
     connected = []
 

--- a/tests/test_dbscan.py
+++ b/tests/test_dbscan.py
@@ -266,6 +266,98 @@ class DBSCANTest(unittest.TestCase):
 
         self.assertTrue(np.array_equal(dense.labels, sparse.labels))
 
+    def test_small_cluster_1(self):
+        """ Tests that DBSCAN can find clusters with less than min_samples. """
+        x = np.array([[0, 0], [0, 1], [1, 0], [3, 0], [5.1, 0], [6, 0], [6, 1],
+                      [10, 10]])
+        ds = load_data(x=x, subset_size=5)
+
+        # n_regions=1
+        dbscan1 = DBSCAN(n_regions=1, eps=2.5, min_samples=4)
+        dbscan1.fit(ds)
+        self.assertEqual(dbscan1.n_clusters, 2)
+
+    def test_small_cluster_2(self):
+        """ Tests that DBSCAN can find clusters with less than min_samples. """
+        x = np.array([[0, 0], [0, 1], [1, 0], [3, 0], [5.1, 0], [6, 0], [6, 1],
+                      [10, 10]])
+        ds = load_data(x=x, subset_size=5)
+
+        # n_regions=10
+        dbscan2 = DBSCAN(n_regions=10, eps=2.5, min_samples=4)
+        dbscan2.fit(ds)
+        self.assertEqual(dbscan2.n_clusters, 2)
+
+    def test_cluster_between_regions_1(self):
+        """ Tests that DBSCAN can find clusters between regions. """
+        x = np.array([[0, 0], [3.9, 0], [4.1, 0], [4.1, 0.89], [4.1, 0.88],
+                      [5.9, 0], [5.9, 0.89], [5.9, 0.88], [6.1, 0], [10, 10],
+                      [4.6, 0], [5.4, 0]])
+        ds = load_data(x=x, subset_size=5)
+
+        dbscan = DBSCAN(n_regions=10, eps=0.9, min_samples=4)
+        dbscan.fit(ds)
+        self.assertEqual(dbscan.n_clusters, 1)
+
+    def test_cluster_between_regions_2(self):
+        """ Tests that DBSCAN can find clusters between regions. """
+        x = np.array([[0, 0], [0.6, 0], [0.9, 0], [1.1, 0.2], [0.9, 0.6],
+                      [1.1, 0.8], [1.4, 0.8], [2, 2]])
+        ds = load_data(x=x, subset_size=5)
+
+        dbscan = DBSCAN(n_regions=2, eps=0.5, min_samples=3)
+        dbscan.fit(ds)
+        self.assertEqual(dbscan.n_clusters, 1)
+
+    def test_cluster_between_regions_3(self):
+        """ Tests that DBSCAN can find clusters between regions. """
+        x = np.array([[0, 0], [0.6, 0], [0.6, 0.01], [0.9, 0], [1.1, 0.2],
+                      [1.4, 0.2], [1.4, 0.21], [0.9, 0.6], [0.6, 0.6],
+                      [0.6, 0.61], [1.1, 0.8], [1.4, 0.8], [1.4, 0.81],
+                      [2, 2]])
+        ds = load_data(x=x, subset_size=5)
+
+        dbscan = DBSCAN(n_regions=2, eps=0.5, min_samples=3)
+        dbscan.fit(ds)
+        self.assertEqual(dbscan.n_clusters, 1)
+
+    def test_random_clusters_1(self):
+        """ Tests DBSCAN on random data with multiple clusters. """
+        # 1 dimension
+        np.random.seed(1)
+        x = np.random.uniform(0, 10, size=(1000, 1))
+        ds = load_data(x=x, subset_size=300)
+        dbscan = DBSCAN(n_regions=100, eps=0.1, min_samples=20)
+        dbscan.fit(ds)
+
+        self.assertEqual(dbscan.n_clusters, 18)
+        self.assertEqual(np.count_nonzero(ds.labels == -1), 72)
+
+    def test_random_clusters_2(self):
+        """ Tests DBSCAN on random data with multiple clusters. """
+        # 2 dimensions
+        np.random.seed(2)
+        x = np.random.uniform(0, 10, size=(1000, 2))
+        ds = load_data(x=x, subset_size=300)
+        dbscan = DBSCAN(n_regions=10, max_samples=10, eps=0.5, min_samples=10)
+        dbscan.fit(ds)
+
+        self.assertEqual(dbscan.n_clusters, 27)
+        self.assertEqual(np.count_nonzero(ds.labels == -1), 206)
+
+    def test_random_clusters_3(self):
+        """ Tests DBSCAN on random data with multiple clusters. """
+        # 3 dimensions
+        np.random.seed(3)
+        x = np.random.uniform(0, 10, size=(1000, 3))
+        ds = load_data(x=x, subset_size=300)
+        dbscan = DBSCAN(n_regions=10, dimensions=[0, 1],
+                        eps=0.9, min_samples=4)
+        dbscan.fit(ds)
+
+        self.assertEqual(dbscan.n_clusters, 50)
+        self.assertEqual(np.count_nonzero(ds.labels == -1), 266)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
# Description

Fixed the bugs from #199, with a significant refactor of the `_compute_neighbors()`, `_compute_labels()` (now `_compute_cp_labels()`) and `_get_equivalences()` tasks. Added more comprehensive tests to check these bugs.

The serialization/deserialization of the neighbors list was the main bottleneck, and this problem was worsened by using them in another task. To reduce the problem, neighbors have been split in different classes (neighbors of non-core points, neighbors of core points within the region and neighbors of core points outside of the region) to be used by different tasks. Furthermore, performance has been improved by using only one-directional neighbouring relations when possible. 

Experimental observations:
- The main bottleneck is still the serialization/deserialization of all the neighbors, specially for regions with high density.
- Scratch is slightly faster than gpfs, which has some overhead on the reductions.

Fixes #199 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (less memory, more speed)

# How Has This Been Tested?

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [x] I have tested it manually in a **supercomputer**.

Reproduce instructions:

The bugs from issue #199 are not reproduced anymore (the reproduction instructions are in the issue).

In MN4, the algorithm has been launched with the smaller Gaia dataset (gpfs and scratch):
`enqueue_compss -t --qos=debug --scheduler=es.bsc.compss.scheduler.fifoDataScheduler.FIFODataScheduler --worker_in_master_cpus=0 --cpus_per_node=30 --worker_working_dir=<gpfs or scratch> --exec_time=120 --num_nodes=16 --base_log_dir=/gpfs/scratch/bsc19/bsc19029/ /home/bsc19/bsc19029/git/dislib/examples/dbscan-driver.py -e 0.19 -m 5 -f 5 -x 5000 -p 10000 -r 17 -d 0,1 --arrange /gpfs/projects/bsc19/COMPSs_DATASETS/dislib/gaia/dbscan/data_scaled.csv`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas.
- [NA] I have documented the public methods of any public class according to the guide styles. 
- [NA] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
