### PR TITLE
Added simple linear regression

### DIFF
--- a/dislib/regression/__init__.py
+++ b/dislib/regression/__init__.py
@@ -1,0 +1,3 @@
+from dislib.regression.linear.base import LinearRegression
+
+__all__ = ['LinearRegression']

--- a/dislib/regression/linear/base.py
+++ b/dislib/regression/linear/base.py
@@ -1,0 +1,140 @@
+import numpy as np
+from pycompss.api.parameter import INOUT
+
+from pycompss.api.task import task
+
+
+class LinearRegression:
+    """
+    Simple linear regression using ordinary least squares.
+
+    model: y1 = alpha + beta*x_i + epsilon_i
+    goal: y = alpha + beta*x
+
+    Parameters
+    ----------
+    arity : int
+        Arity of the reductions.
+
+    Attributes
+    ----------
+    coef_ : array, shape (n_features, )
+        Estimated coefficients (beta) for the linear model.
+    intercept_ : float
+        Estimated independent term (alpha) in the linear model.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> train_x = np.array([1, 2, 3, 4, 5])[:, np.newaxis]
+    >>> train_y = np.array([2, 1, 1, 2, 4.5])
+    >>> from dislib.data import load_data
+    >>> train_dataset = load_data(x=train_x, y=train_y, subset_size=2)
+    >>> from dislib.regression import LinearRegression
+    >>> reg = LinearRegression()
+    >>> reg.fit(train_dataset)
+    >>> # y = 0.6 * x + 0.3
+    >>> reg.coef_
+    0.6
+    >>> reg.intercept_
+    0.3
+    >>> test_x = np.array([3, 5])[:, np.newaxis]
+    >>> test_dataset = load_data(x=test_x, subset_size=2)
+    >>> reg.predict(test_dataset)
+    >>> test_dataset.labels
+    array([2.1, 3.3])
+    """
+
+    def __init__(self, arity=50):
+        self._arity = arity
+
+    def fit(self, dataset):
+        """
+        Fit the linear model.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            Training dataset: x.shape (n_samples, 1), y.shape (n_samples, ).
+        """
+        mean_x, mean_y = _variable_means(dataset, self._arity)
+        beta, alpha = _compute_regression(dataset, mean_x, mean_y, self._arity)
+        self.coef_ = beta
+        self.intercept_ = alpha
+
+    def predict(self, dataset):
+        """
+        Predict using the linear model.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            Dataset with samples: x.shape (n_samples, 1). Predicted values are
+            populated in the labels attribute.
+        """
+        for subset in dataset:
+            _predict(subset, self.coef_, self.intercept_)
+
+
+def _reduce(func, partials, arity):
+    while len(partials) > 1:
+        partials_chunk = partials[:arity]
+        partials = partials[arity:]
+        partials.append(func(*partials_chunk))
+    return partials[0]
+
+
+def _variable_means(dataset, arity):
+    partials = [_sum_and_count_samples(subset) for subset in dataset]
+    total_sums_and_count = _reduce(_sum_params, partials, arity)
+    mean_x, mean_y = _divide_sums_by_count(total_sums_and_count)
+    return mean_x, mean_y
+
+
+@task(returns=1)
+def _sum_and_count_samples(subset):
+    partial_sum_x = np.sum(subset.samples[:, 0])
+    partial_sum_y = np.sum(subset.labels)
+    return partial_sum_x, partial_sum_y, subset.samples.shape[0]
+
+
+@task(returns=1)
+def _sum_params(*partials):
+    return tuple(sum(p) for p in zip(*partials))
+
+
+@task(returns=2)
+def _divide_sums_by_count(sums_and_count):
+    sum_x, sum_y, count = sums_and_count
+    return sum_x/count, sum_y/count
+
+
+def _compute_regression(dataset, mean_x, mean_y, arity):
+    partials = []
+    for subset in dataset:
+        partials.append(_partial_variability_params(subset, mean_x, mean_y))
+    variability_params = _reduce(_sum_params, partials, arity)
+    return _calculate_coefficients(mean_x, mean_y, variability_params)
+
+
+@task(returns=1)
+def _partial_variability_params(subset, mean_x, mean_y):
+    normalized_x = subset.samples[:, 0] - mean_x
+    normalized_y = subset.labels - mean_y
+    normalized_xy_dot = np.dot(normalized_x, normalized_y)
+    normalized_xx_dot = np.dot(normalized_x, normalized_x)
+    return normalized_xy_dot, normalized_xx_dot
+
+
+@task(returns=2)
+def _calculate_coefficients(mean_x, mean_y, variability_params):
+    dot_xy, dot_xx = variability_params
+    beta = dot_xy / dot_xx
+    alpha = mean_y - beta*mean_x
+    return beta, alpha
+
+
+@task(subset=INOUT)
+def _predict(subset, coef, intercept):
+    subset.labels = coef*subset.samples[:, 0] + intercept
+    return subset

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -107,6 +107,15 @@ Classes
 - Distributed alternating least squares for collaborative filtering.
 
 
+dislib.regression: Regression
+-----------------------------
+
+Classes
+.......
+
+:class:`regression.LinearRegression <dislib.regression.linear.base.LinearRegression>`
+- Simple linear regression using ordinary least squares.
+
 
 dislib.neighbors: Neighbor queries
 ----------------------------------

--- a/docs/source/dislib.regression.linear.rst
+++ b/docs/source/dislib.regression.linear.rst
@@ -1,0 +1,7 @@
+dislib.regression.LinearRegression
+==================================
+
+.. automodule:: dislib.regression.linear.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/dislib.rst
+++ b/docs/source/dislib.rst
@@ -12,8 +12,9 @@ Subpackages
     dislib.neighbors
     dislib.cluster.dbscan
     dislib.recommendation.als
-    dislib.data
     dislib.decomposition.pca
+    dislib.regression.linear
+    dislib.data
     dislib.other
 
 .. automodule:: dislib

--- a/examples/linear_regression_plot.py
+++ b/examples/linear_regression_plot.py
@@ -1,0 +1,35 @@
+import numpy as np
+from pycompss.api.api import compss_wait_on
+from pylab import scatter, plot, show
+
+from dislib.data import load_data
+from dislib.regression import LinearRegression
+
+
+def main():
+    """
+    Linear regression example with plot
+    """
+
+    # Example data
+    x = np.array([1000, 4000, 5000, 4500, 3000, 4000, 9000, 11000, 15000,
+                  12000, 7000, 3000])
+    y = np.array([9914, 40487, 54324, 50044, 34719, 42551, 94871, 118914,
+                  158484, 131348, 78504, 36284])
+
+    ds = load_data(x=x[:, np.newaxis], y=y, subset_size=4)
+    reg = LinearRegression()
+    reg.fit(ds)
+    reg.coef_ = compss_wait_on(reg.coef_)
+    reg.intercept_ = compss_wait_on(reg.intercept_)
+    print(reg.coef_, reg.intercept_)
+
+    # plot_result:
+    scatter(x, y, marker='x')
+    x_mesh = np.linspace(min(x), max(x), 1000)
+    plot(x_mesh, [reg.coef_*x + reg.intercept_ for x in x_mesh])
+    show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gm.py
+++ b/tests/test_gm.py
@@ -418,6 +418,7 @@ class GaussianMixtureTest(unittest.TestCase):
         self.assertTrue(gm.converged_)
 
     def test_precisions_init_full(self):
+        """ Tests GaussianMixture with precisions_init='full' """
         x, _ = load_iris(return_X_y=True)
         dataset = load_data(x, subset_size=75)
         weights_init = [1/3, 1/3, 1/3]
@@ -436,6 +437,7 @@ class GaussianMixtureTest(unittest.TestCase):
         self.assertTrue(gm.converged_)
 
     def test_precisions_init_tied(self):
+        """ Tests GaussianMixture with precisions_init='tied' """
         x, _ = load_iris(return_X_y=True)
         dataset = load_data(x, subset_size=75)
         weights_init = [1/3, 1/3, 1/3]
@@ -454,6 +456,7 @@ class GaussianMixtureTest(unittest.TestCase):
         self.assertTrue(gm.converged_)
 
     def test_precisions_init_diag(self):
+        """ Tests GaussianMixture with precisions_init='diag' """
         x, _ = load_iris(return_X_y=True)
         dataset = load_data(x, subset_size=75)
         weights_init = np.array([1/3, 1/3, 1/3])
@@ -471,6 +474,7 @@ class GaussianMixtureTest(unittest.TestCase):
         self.assertTrue(gm.converged_)
 
     def test_precisions_init_spherical(self):
+        """ Tests GaussianMixture with precisions_init='spherical' """
         x, _ = load_iris(return_X_y=True)
         dataset = load_data(x, subset_size=75)
         weights_init = [1/3, 1/3, 1/3]

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+from pycompss.api.api import compss_wait_on
+
+from dislib.data import load_data
+from dislib.regression import LinearRegression
+
+
+class LinearRegressionTest(unittest.TestCase):
+
+    def test_fit_and_predict(self):
+        """Tests LinearRegression's fit() and predict()"""
+        x = np.array([1, 2, 3, 4, 5])[:, np.newaxis]
+        y = np.array([2, 1, 1, 2, 4.5])
+        train_data = load_data(x=x, y=y, subset_size=2)
+        reg = LinearRegression()
+        reg.fit(train_data)
+        # y = 0.6 * x + 0.3
+
+        reg.coef_ = compss_wait_on(reg.coef_)
+        reg.intercept_ = compss_wait_on(reg.intercept_)
+
+        self.assertTrue(np.allclose(reg.coef_, 0.6))
+        self.assertTrue(np.allclose(reg.intercept_, 0.3))
+
+        x_test = np.array([3, 5])[:, np.newaxis]
+        test_data = load_data(x=x_test, subset_size=2)
+        reg.predict(test_data)
+        prediction = test_data.labels
+        self.assertTrue(np.allclose(prediction, [2.1, 3.3]))
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Description

Added new module for (simple) linear regression. It is based on the algorithm we had in the apps repository: a simple linear regression (1 explanatory variable, 1 dependent variable). The model is a line `y = alpha + beta*x`. The attribute names are `coef_` and `intercept_`, as in scikit-learn.

The scikit-learn implementation supports multiple linear regression (multiple explanatory variables). To do that, we would need a new implementation, because the underlying calculations are different (matrix based).

Fixes #201 

## Type of change

- [x] New algorithm or support class.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions:

An script which plots the regression of a simple example has been added in the examples folder.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have documented the public methods of any public class according to the guide styles. 
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
