### PR TITLE
rf: fixed predict_proba bug

### DIFF
--- a/dislib/regression/linear/base.py
+++ b/dislib/regression/linear/base.py
@@ -9,17 +9,18 @@ class LinearRegression:
     Simple linear regression using ordinary least squares.
 
     model: y1 = alpha + beta*x_i + epsilon_i
+
     goal: y = alpha + beta*x
 
     Parameters
     ----------
-    arity : int
+    arity : int, optional (default=50)
         Arity of the reductions.
 
     Attributes
     ----------
     coef_ : array, shape (n_features, )
-        Estimated coefficients (beta) for the linear model.
+        Estimated coefficient (beta) in the linear model.
     intercept_ : float
         Estimated independent term (alpha) in the linear model.
 

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -1,6 +1,7 @@
 import unittest
 
 from pycompss.api.api import compss_wait_on
+from sklearn import datasets
 from sklearn.datasets import make_classification
 
 from dislib.classification import RandomForestClassifier
@@ -197,6 +198,20 @@ class RFTest(unittest.TestCase):
         rf.fit(train_ds)
         accuracy = rf.score(test_ds)
         self.assertGreater(accuracy, 0.7)
+
+    def test_iris(self):
+        """Tests RandomForestClassifier with a minimal example."""
+        x, y = datasets.load_iris(return_X_y=True)
+        ds_fit = load_data(x[::2], 30, y[::2])
+        ds_validate = load_data(x[1::2], 30, y[1::2])
+        rf = RandomForestClassifier(n_estimators=1, max_depth=1,
+                                    random_state=0)
+        rf.fit(ds_fit)
+        accuracy = rf.score(ds_validate)
+
+        # Accuracy should be <= 0.666... , often exactly equal.
+        self.assertLess(accuracy, 0.67)
+        self.assertGreater(accuracy, 0.34)
 
 
 def main():

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -209,9 +209,8 @@ class RFTest(unittest.TestCase):
         rf.fit(ds_fit)
         accuracy = rf.score(ds_validate)
 
-        # Accuracy should be <= 0.666... , often exactly equal.
-        self.assertLess(accuracy, 0.67)
-        self.assertGreater(accuracy, 0.34)
+        # Accuracy should be <= 2/3 for any seed, often exactly equal.
+        self.assertAlmostEqual(accuracy, 2/3)
 
 
 def main():


### PR DESCRIPTION
# Description

Fixed a bug in the DecisionTree predict_proba() method that caused the probability in impure leaf nodes not to be computed (the probability was casted from float to int and thus converted to 0 if it was <1). This worsened the accuracy of the algorithm in some cases.

The fix shouldn't have any impact on running time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The new test case, RFTest.test_iris, tests the RandomForestClassifier with n_estimators=1 and max_depth=1 (to have impure leaves). Before the fix, the accuracy was 0.333... and after the fix it can go up to 0.666..., having same values and variability as sklearn reuslts.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions:
The new test case can be tested with the new and the old codebase. The equivalent code in sklearn is very similar. Running them on a loop and printing the accuracies doesn't show any significant difference between sklearn and dislib after the bugfix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas.
- [NA] I have documented the public methods of any public class according to the guide styles. 
- [NA] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
