### PR TITLE
Support for jupyter in docker

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -35,13 +35,13 @@ numpydoc >= 0.8.0 is requried to build the documentation.
     * Extract the contents of the tar package.
     
     ```bash
-    tar xzvf dislib-0.1.1.tar.gz
+    tar xzvf dislib-X.Y.Z.tar.gz
     ```
     
     * Run an example application.
     
     ```bash
-    runcompss --python_interpreter=python3 dislib-0.1.1/examples/kmeans.py    
+    runcompss --python_interpreter=python3 dislib-X.Y.Z/examples/kmeans.py    
     ```
 
 ### Using docker
@@ -109,15 +109,15 @@ dislib init
 dislib init /home/user/replace/path/
 ```
 
-#### 4. Run a sample application
+#### 4. Running applications
 
 **Note**: running the docker dislib does not work with applications with GUI or with visual plots such as `examples/clustering_comparison.py`).
 
-First clone dislib repo and checkout release 0.1.0 (docker version and dislib code should preferably be the same to avoid inconsistencies):
+First clone dislib repo and checkout release branch vX.Y.Z (docker version and dislib code should preferably be the same to avoid inconsistencies):
 
 ```bash
 git clone https://github.com/bsc-wdc/dislib.git
-git co v0.1.0
+git co vX.Y.Z
 ```
 
 Init the dislib environment in the root of the repo.
@@ -138,11 +138,26 @@ dislib init
 dislib exec rf_iris.py
 ```
 
-#### 5. Adding more nodes
+#### 5. Running Jupyter notebooks
+
+Notebooks can be run using the `dislib run` command. Run the following snippet from the root of the project:
+
+```bash
+dislib init
+dislib run jupyter-notebook ./notebooks --ip=0.0.0.0  --allow-root
+```
+
+Access your notebook by ctrl-clicking or copy pasting into the browser the link shown on the CLI (e.g. http://127.0.0.1:8888/?token=TOKEN_VALUE).
+
+If the notebook process is not properly closed, you might get the following warning when trying to start jupyter notebooks again:
+
+`The port 8888 is already in use, trying another port.`
+
+To fix it, just restart the dislib container with `dislib init`.
+#### 6. Adding more nodes
 
 
-**Note**: adding more nodes is still in beta phase. Any suggestion, issue, or feedback is highly welcome and appreciated.
-
+**Note**: adding more nodes is still in beta phase. Please report issues, suggestions, or feature requests on [Github](https://github.com/bsc-wdc/dislib).
 
 To add more computing nodes, you can either let docker create more workers for you or manually create and config a custom node.
 

--- a/bin/dislib
+++ b/bin/dislib
@@ -17,7 +17,8 @@ if [ -z "${cmd}" ]; then
     echo "    init [WORK_DIR]:         initializes dislib in the current working dir or in WORK_DIR args is set."
     echo "    kill:                    stops and kills all instances of the dislib."
     echo "    update:                  updates the dislib docker image (use only when installing master branch)."
-    echo "    exec FILE [PARAMS]:      executes the FILE inside the container with the given COMPSs [PARAMS]"
+    echo "    run CMD:                 executes the CMD command inside the dislib master container."
+    echo "    exec FILE [PARAMS]:      executes the FILE inside the dislib master container with the given COMPSs [PARAMS]"
     echo "    components list:         lists dislib actives components."
     echo "    components add RESOURCE: adds the RESOURCE to the pool of workers of the dislib."
     echo ""
@@ -35,7 +36,7 @@ if [ "${cmd}" == "kill" ]; then
     python3 -c "from dislib_cmd import _stop_daemon; _stop_daemon()"
 fi
 if [ "${cmd}" == "run" ]; then    subcmd=$@
-    python3 -c "from dislib_cmd import _exec_in_daemon; _exec_in_daemon('${subcmd})"
+    python3 -c "from dislib_cmd import _exec_in_daemon; _exec_in_daemon('${subcmd}')"
 fi
 if [ "${cmd}" == "exec" ]; then
     file=$1

--- a/bin/dislib_cmd.py
+++ b/bin/dislib_cmd.py
@@ -64,9 +64,9 @@ def _start_daemon(working_dir: str = "", restart: bool = True):
               "patient.")
 
         mounts = _get_mounts(user_working_dir=working_dir)
-
+        ports = {'8888/tcp': 8888}  # required for jupyter notebooks
         m = client.containers.run(image=image_name, name=master_name,
-                                  mounts=mounts, detach=True)
+                                  mounts=mounts, detach=True, ports=ports)
 
         _generate_resources_cfg(ips=['localhost'])
         _generate_project_cfg(ips=['localhost'])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
     openmpi-bin openmpi-doc libopenmpi-dev uuid-runtime curl bc \
 # Python-binding dependencies
     python3-dev python3-pip python3-setuptools && \
-    pip3 install wheel dill decorator coverage numpy==1.15.4 scipy==1.3.0 \
+    pip3 install wheel dill decorator coverage numpy==1.15.4 scipy==1.3.0 jupyter==1.0.0 \
     scikit-learn==0.19.1 pandas==0.23.1 matplotlib==2.2.3 flake8 codecov && \
 # Configure user environment
 # =============================================================================

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -46,6 +46,8 @@ Follow these steps when drafting a new release:
     .. code:: bash
      
        docker build -t bscwdc/dislib:VERSION .
+       # Create also new 'latest' tag using newly created image
+       docker tag bscwdc/dislib:VERSION bscwdc/dislib:latest
    
     - Log in and push it to dockerhub
    
@@ -53,6 +55,7 @@ Follow these steps when drafting a new release:
 
        docker login -u DOCKERHUB_USER -p DOCKERHUB_PASSWORD
        docker push bscwdc/dislib:VERSION
+       docker push bscwdc/dislib:latest
 
 12. Create a pip package and upload it to PyPi:
 


### PR DESCRIPTION
Signed-off-by: Pol Alvarez Vecino <pol.avms@gmail.com>

This pull requests adds minor fixes to allow jupyter to be run inside dislib docker container. This PR can be tested following the updated instructions on Quickstart.md. 

The current `bscwdc/dislib:latest` docker image pushed to dockerhub already contains jupyter. To update the local latest image first remove it using `docker rmi bscwdc/dislib:latest` and then proceed with the quickstart instructions to run jupyter inside dislib's container.

## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Running the jupyter notebook inside the `./notebooks' folder as described in the docs section Quickstart.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [X] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have documented the public methods of any public class according to the guide styles. 
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased my branch before trying to merge.
