### PR TITLE
PCA sparse support, LR to raise error

### DIFF
--- a/dislib/decomposition/pca/base.py
+++ b/dislib/decomposition/pca/base.py
@@ -172,7 +172,7 @@ def _finalize_features_mean(feature_sums, n_samples):
       out_blocks={Type: COLLECTION_INOUT, Depth: 1})
 def _normalize(blocks, out_blocks, means):
     data = Array._merge_blocks(blocks)
-    data = data - means
+    data = np.array(data - means)
 
     bn, bm = blocks[0][0].shape
 

--- a/dislib/regression/linear/base.py
+++ b/dislib/regression/linear/base.py
@@ -64,7 +64,14 @@ class LinearRegression:
         y : ds-array
             Labels of the samples
 
+        Raises
+        ------
+        NotImplementedError
+            If x is a sparse array.
+
         """
+        if x._sparse or y._sparse:
+            raise NotImplementedError('Sparse data is not supported.')
         mean_x, mean_y = _variable_means(x, y, self._arity)
         beta, alpha = _compute_regression(x, y, mean_x, mean_y, self._arity)
         self.coef_ = beta
@@ -78,11 +85,20 @@ class LinearRegression:
         ----------
         x : ds-array
             Samples to be predicted: x.shape (n_samples, 1).
+
         Returns
         -------
         y : ds-array
             Predicted values
+
+        Raises
+        ------
+        NotImplementedError
+            If x is a sparse array.
+
         """
+        if x._sparse:
+            raise NotImplementedError('Sparse data is not supported.')
 
         blocks = [list()]
 

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -1,10 +1,12 @@
 import unittest
 
 import numpy as np
+from scipy.sparse import random as sp_random
 from pycompss.api.api import compss_wait_on
 
 import dislib as ds
 from dislib.regression import LinearRegression
+from dislib.data import random_array
 
 
 class LinearRegressionTest(unittest.TestCase):
@@ -34,6 +36,19 @@ class LinearRegressionTest(unittest.TestCase):
         pred = reg.predict(test_data).collect()
 
         self.assertTrue(np.allclose(pred, [2.1, 3.3]))
+
+    def test_sparse(self):
+        """Tests LR raises NotImplementedError for sparse data."""
+        np.random.seed(0)
+        coo_matrix = sp_random(10, 1, density=0.5)
+        sparse_arr = ds.array(x=coo_matrix, block_size=(5, 1))
+        reg = LinearRegression()
+        with self.assertRaises(NotImplementedError):
+            reg.fit(sparse_arr, sparse_arr)
+        dense_arr = random_array((10, 1), (5, 1))
+        reg.fit(dense_arr, dense_arr)
+        with self.assertRaises(NotImplementedError):
+            reg.predict(sparse_arr)
 
 
 def main():

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -70,6 +70,27 @@ class PCATest(unittest.TestCase):
             features_opposite = np.allclose(transformed[:, i], -expected[:, i])
             self.assertTrue(features_equal or features_opposite)
 
+    def test_sparse(self):
+        """ Tests PCA produces the same results using dense and sparse
+        data structures. """
+        file_ = "tests/files/libsvm/2"
+        x_sp, _ = ds.load_svmlight_file(file_, (10, 300), 780, True)
+        x_ds, _ = ds.load_svmlight_file(file_, (10, 300), 780, False)
+
+        pca = PCA()
+        transform_dense = pca.fit_transform(x_ds).collect()
+        dense_components = pca.components_
+        dense_variance = pca.explained_variance_
+
+        pca = PCA()
+        transform_sparse = pca.fit_transform(x_sp).collect()
+        sparse_components = pca.components_
+        sparse_variance = pca.explained_variance_
+
+        self.assertTrue(np.array_equal(transform_sparse, transform_dense))
+        self.assertTrue(np.allclose(sparse_components, dense_components))
+        self.assertTrue(np.allclose(sparse_variance, dense_variance))
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
# Description

Support for sparse arrays in PCA. For LinearRegression, a NotImplementedError is raised.