### PR TITLE
Fixed docs links to source for objects in __all__

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -342,6 +342,8 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
+    modname = inspect.getmodule(obj).__name__
+
     return "http://github.com/bsc-wdc/dislib/blob/master/%s.py%s" \
            % (modname.replace(".", "/"), linespec)
 


### PR DESCRIPTION
# Description

Fixed docs link docs to source file for objects that are not defined in the same source file (for example, when objects are imported and added to `__all__`).

The generated docs are available [here](https://dislib.bsc.es/en/issue-259/).

Fixes #259