### PR TITLE
Docs source now points to proper release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 
 import inspect
 import os
+import subprocess as subp
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -61,8 +62,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'dislib'
-copyright = '2019, Workflows and Distributed Computing'
-author = 'Workflows and Distributed Computing'
+copyright = '2019, Barcelona Supercomputing Center (BSC)'
+author = 'Barcelona Supercomputing Center (BSC)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -256,7 +257,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'dislib.tex', 'dislib Documentation',
-     'Workflows and Distributed Computing', 'manual'),
+     'Barcelona Supercomputing Center', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -344,8 +345,15 @@ def linkcode_resolve(domain, info):
 
     modname = inspect.getmodule(obj).__name__
 
-    return "http://github.com/bsc-wdc/dislib/blob/master/%s.py%s" \
-           % (modname.replace(".", "/"), linespec)
+    try:
+        branch = subp.getoutput(["git branch | grep origin | cut -d' ' -f5"])
+        branch = branch.split("/")[1][:-1]
+    except subp.CalledProcessError as e:
+        print("Error getting branch name. I will use master:\n", e.output)
+        branch = "master"
+
+    return "http://github.com/bsc-wdc/dislib/blob/%s/%s.py%s" \
+           % (branch, modname.replace(".", "/"), linespec)
 
 
 # -- Options for Texinfo output -------------------------------------------


### PR DESCRIPTION
Changed how the documentation is built so that the source links point to the proper version in github. 

However, this will not work for the 'latest' version of the documentation (that should point to the 'master' branch) because the version of the code is read from the VERSION file. And the VERSION file contains an X.Y.Z number.

There are two possible solutions for this:

- Deactivate the latest version of the documentation as it is unstable anyways (and I am not sure if users should be checking it)

- Place a `0.0.0` or something like that in the VERSION file of the master branch to indicate that we are in the master branch.

FIxes #261 