### PR TITLE
Make KFold not to shuffle by default

### DIFF
--- a/dislib/model_selection/_split.py
+++ b/dislib/model_selection/_split.py
@@ -61,7 +61,7 @@ class KFold:
         by `np.random`. Used when ``shuffle`` == True.
     """
 
-    def __init__(self, n_splits=5, shuffle=True, random_state=None):
+    def __init__(self, n_splits=5, shuffle=False, random_state=None):
         if not isinstance(n_splits, numbers.Integral):
             raise ValueError('The number of folds must be of Integral type. '
                              '%s of type %s was passed.'

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -11,6 +11,7 @@ from dislib.neighbors import NearestNeighbors
 from dislib.recommendation import ALS
 from dislib.regression import LinearRegression
 from dislib.model_selection import GridSearchCV, KFold
+from dislib.utils import shuffle
 
 
 class GridSearchCVTest(unittest.TestCase):
@@ -81,14 +82,17 @@ class GridSearchCVTest(unittest.TestCase):
 
     def test_refit_false(self):
         """Tests GridSearchCV fit() with refit=False."""
-        x, y = datasets.load_iris(return_X_y=True)
-        x_dsarray = ds.array(x, (30, 4))
-        y_dsarray = ds.array(y[:, np.newaxis], (30, 1))
+        x_np, y_np = datasets.load_iris(return_X_y=True)
+        x = ds.array(x_np, (30, 4))
+        y = ds.array(y_np[:, np.newaxis], (30, 1))
+
+        seed = 0
+        x, y = shuffle(x, y, random_state=seed)
 
         param_grid = {'max_iter': range(1, 5)}
         csvm = CascadeSVM(check_convergence=False)
         searcher = GridSearchCV(csvm, param_grid, cv=3, refit=False)
-        searcher.fit(x_dsarray, y_dsarray)
+        searcher.fit(x, y)
 
         self.assertFalse(hasattr(searcher, 'best_estimator_'))
         self.assertTrue(hasattr(searcher, 'best_score_'))


### PR DESCRIPTION
# Description

`KFold` parameter `shuffle` was set to `True` by default, in opposition to the documentation. This caused `GridSearchCV` not to be reproducible even with reproducible estimators.

I've set `KFold(..., shuffle=False)`.

The fix caused a test of GridSearchCV with CascadeSVM to fail, because CascadeSVM needs to have the 2 classes in each data partition. I fixed it adding an initial preshuffle of the dataset in the test.

Fixes #265

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas.
- [N/A] I have documented the public methods of any public class according to the guide styles. 
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
