### PR TITLE
Fixing empty blocks issue in merge_slices() for GridSearchCV

### DIFF
--- a/dislib/model_selection/_split.py
+++ b/dislib/model_selection/_split.py
@@ -178,8 +178,10 @@ def merge_slices(s1, s2):
 
     # Add the regular row blocks to the list all_blocks
     all_blocks = []
-    all_blocks.extend(reg_s1._blocks)
-    all_blocks.extend(reg_s2._blocks)
+    if reg_s1.shape[0]:
+        all_blocks.extend(reg_s1._blocks)
+    if reg_s2.shape[0]:
+        all_blocks.extend(reg_s2._blocks)
 
     # If there are remaining rows on the top or bottom of s1 and s2, add them
     # to the list extras. These are row blocks with less than reg_rows.


### PR DESCRIPTION
# Description

The method `merge_slices(s1, s2)` added the regular blocks of `s1` and `s2` to the merged array. When there was no regular block in one of the slices, an empty row block was added to the result and an error was eventually raised.

This case happened when the KFold size was less than 2 times the number of rows in a regular block, i.e., when having few blocks and high number of folds.

The fix was a simple check for empty ds-arrays.

Fixes #267

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [x] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas.
- [N/A] I have documented the public methods of any public class according to the guide styles. 
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
