### PR TITLE
Fixed dislib executable in MacOS

### DIFF
--- a/bin/dislib
+++ b/bin/dislib
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-#cmd_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-cmd_path="$(dirname "$(readlink -f "$0")")"
+getpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+cmd_path=$(dirname $(getpath "$0"))
+
 cmd=$1
 shift 1
 


### PR DESCRIPTION
# Description

Fixed dislib executable for MacOS by replacing readlink with a different way of getting the script's path.


Fixes #239 