### PR TITLE
fixed internal inconsistencies in transformed_array of PCA

### DIFF
--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -50,7 +50,9 @@ class PCATest(unittest.TestCase):
         dataset = ds.array(x=x, block_size=(bn, bm))
 
         pca = PCA(n_components=3)
-        transformed = pca.fit_transform(dataset).collect()
+        transformed = pca.fit_transform(dataset)
+        self.assertEqual(transformed.shape, (10, 3))
+        transformed = transformed.collect()
         expected = np.array([
             [-6.35473531, -2.7164493, -1.56658989],
             [7.929884, -1.58730182, -0.34880254],


### PR DESCRIPTION
# Description

PCA transform() and fit_transform() returned a transformed_array ds-array with inconsistencies when n_components < n_features, including wrong shape and empty blocks, and miss-aligned block shapes. This bug has been fixed and a test for the checking the shape added.

## Type of change

Please delete options that are not relevant.

- [ ] New algorithm or support class.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. If you haven't added any test and it is relevant provide instructions so we can reproduce.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas.
- [NA] I have documented the public methods of any public class according to the guide styles. 
- [NA] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch before trying to merge.
