### PR TITLE
Fixed block_size in classifier_comparison.py

### DIFF
--- a/examples/classifier_comparison.py
+++ b/examples/classifier_comparison.py
@@ -42,9 +42,9 @@ def main():
         x_train, x_test, y_train, y_test = \
             train_test_split(x, y, test_size=.4, random_state=42)
         ds_x_train = ds.array(x_train, block_size=(20, 2))
-        ds_y_train = ds.array(y_train.reshape(-1, 1), block_size=(20, 2))
+        ds_y_train = ds.array(y_train.reshape(-1, 1), block_size=(20, 1))
         ds_x_test = ds.array(x_test, block_size=(20, 2))
-        ds_y_test = ds.array(y_test.reshape(-1, 1), block_size=(20, 2))
+        ds_y_test = ds.array(y_test.reshape(-1, 1), block_size=(20, 1))
 
         x_min, x_max = x[:, 0].min() - .5, x[:, 0].max() + .5
         y_min, y_max = x[:, 1].min() - .5, x[:, 1].max() + .5


### PR DESCRIPTION
# Description

Fixed block_size in classifier_comparison.py (apparently now block_size cannot be bigger than the arrays shape).

Fixes #315

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [x] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions:
```
cd examples
python3 classifier_comparison.py
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have documented the public methods of any public class according to the guide styles. 
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased my branch before trying to merge.
