### PR TITLE
Updated docker image to COMPSs/2.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 sh 'git lfs pull origin'
                 sh 'docker rm -f dislib &> /dev/null || true'
                 sh 'docker rmi -f bscwdc/dislib &> /dev/null || true'
-                sh 'docker build --no-cache --tag bscwdc/dislib .'
+                sh 'docker build --pull --no-cache --tag bscwdc/dislib .'
                 sh '''#!/bin/bash
                 docker run $(bash <(curl -s https://codecov.io/env)) -d --name dislib bscwdc/dislib'''
             }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,11 +41,14 @@ RUN apt-get update && \
     libxml2 gfortran libpapi-dev papi-tools \
 # Misc. dependencies
     openmpi-bin openmpi-doc libopenmpi-dev uuid-runtime curl bc \
-# Python-binding dependencies
+# Python-binding and dislib dependencies
     python3-dev python3-pip python3-setuptools && \
     pip3 install wheel dill decorator coverage numpy==1.15.4 ipython==7.9.0 \
     scipy==1.3.0 jupyter==1.0.0 scikit-learn==0.19.1 pandas==0.23.1 \
-    matplotlib==2.2.3 cvxpy==1.1.5 flake8 codecov parameterized && \
+    matplotlib==2.2.3 flake8 codecov parameterized && \
+# cvxpy dependency
+    pip3 install --no-deps scs && \
+    pip3 install cvxpy==1.1.5 && \
 # Configure user environment
 # =============================================================================
 # System configuration
@@ -56,7 +59,7 @@ RUN apt-get update && \
     echo "LD_LIBRARY_PATH=/usr/lib/openmpi/lib" >> /etc/environment && \
     mkdir /run/sshd && \
 # Clone framework files for installation
-    git clone --depth=1 --branch 2.7 https://github.com/bsc-wdc/compss.git framework && \
+    git clone --depth=1 --branch 2.8 https://github.com/bsc-wdc/compss.git framework && \
 # Install COMPSs
     cd /framework && \
     ./submodules_get.sh && \


### PR DESCRIPTION
# Description

Updated the docker-base Dockerfile to COMPSs/2.8 (just deployed to Dockerhub). With this we can use COMPSs2.8 features in dislib.

The installation of cvxpy==1.1.5 was failing. For some reason, its dependency scs was trying to install numpy 1.20 (although it is not listed as dependency) which is not compatible with the python3.6 of the base image ubuntu18.04. As a workaround, I preinstall scs with `pip3 install --no-deps scs`. All the tests work fine.

## Type of change

- [x] New feature

# How Has This Been Tested?

The run_ci_checks.sh script has been run on the new docker image.