### PR TITLE
Fixed bug on DBSCAN lil_matrix with recent versions of scipy

### DIFF
--- a/dislib/cluster/dbscan/classes.py
+++ b/dislib/cluster/dbscan/classes.py
@@ -212,7 +212,7 @@ def _compute_cp_labels(core_points, *in_cp_neighs):
     core_idx = 0
     for idx, neighbours in zip(core_points.nonzero()[0], in_cp_neighs_iter):
         neighbours = core_ids[neighbours[core_points[neighbours]]]
-        adj_matrix.rows[core_idx] = neighbours
+        adj_matrix.rows[core_idx] = neighbours.tolist()
         adj_matrix.data[core_idx] = [1] * len(neighbours)
         core_idx += 1
 


### PR DESCRIPTION
# Description

DBSCAN uses scipy's lil_matrix. It filled its rows with a numpy array, but this fails with recent versions of scipy (from 1.4... or 1.5...). The fix is converting the numpy array to a list with a tolist() call.

Our docker image has scipy 1.3 so this problem wasn't detected on the tests (I'll add an issue for updating the docker image).