### PR TITLE
fixed estimators notebook bugs with PCA

### DIFF
--- a/notebooks/estimators.ipynb
+++ b/notebooks/estimators.ipynb
@@ -367,7 +367,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sum(pca.explained_variance_[0:10])/sum(pca.explained_variance_)"
+    "explained_variance = pca.explained_variance_.collect()\n",
+    "sum(explained_variance[0:10])/sum(explained_variance)"
    ]
   },
   {
@@ -383,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(np.abs(pca.components_[0]).reshape(28,28))"
+    "plt.imshow(np.abs(pca.components_.collect()[0]).reshape(28,28))"
    ]
   },
   {
@@ -533,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description
Fixed estimators notebook bugs with PCA (now pca.explained_variance_ and pca.components_ are ds-arrays, so they need to be collected before using as numpy arrays).
