### PR TITLE
Improper use of combinations_with_replacement

### DIFF
--- a/dislib/math/base.py
+++ b/dislib/math/base.py
@@ -168,13 +168,11 @@ def svd(a, compute_uv=True, sort=True, copy=True, eps=1e-9):
     while not _check_convergence_svd(checks):
         checks = []
 
-        pairings = itertools.combinations_with_replacement(
+        pairings = itertools.combinations(
             range(x._n_blocks[1]), 2
         )
 
         for i, j in pairings:
-            if i >= j:
-                continue
             coli_x = x._get_col_block(i)
             colj_x = x._get_col_block(j)
 


### PR DESCRIPTION
AFAIU, this is equivalent, more readable, more compact, and more performant.