### PR TITLE
fix mistune package version doc compilation error

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -5,3 +5,4 @@ numpydoc==0.8.0
 cvxpy
 m2r
 docutils<0.18
+mistune==0.8.4


### PR DESCRIPTION
# Description

There was a recent mistune-2.0.0 release that break the compilation.
Solution is to pin `mistune` version to `==0.8.4` in requirements

## Type of change

Please delete options that are not relevant.

- [ ] New algorithm or support class.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. If you haven't added any test and it is relevant provide instructions so we can reproduce.

- [ ] I have added a new test file: [E.g. `test_rf.py`]
- [ ] I have added a new test case: [E.g. `RFTest.test_make_classification`]
- [ ] I have tested it manually in a **local environment**.
- [ ] I have tested it manually in a **supercomputer**.

Reproduce instructions:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have documented the public methods of any public class according to the guide styles. 
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased my branch before trying to merge.