### PR TITLE
fix setup missing files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . dislib/
 
 ENV PYTHONPATH=$PYTHONPATH:/dislib
 ENV LC_ALL=C.UTF-8
-RUN python3 -m pip install --upgrade -r /dislib/requirements.txt
+RUN python3 -m pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade -r /dislib/requirements.txt
 
 ENV COMPSS_LOAD_SOURCE false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM compss/compss:3.0
+FROM bscwdc/dislib-base:latest
 MAINTAINER COMPSs Support <support-compss@bsc.es>
 
 COPY . dislib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bscwdc/dislib-base:latest
+FROM compss/compss:3.0
 MAINTAINER COMPSs Support <support-compss@bsc.es>
 
 COPY . dislib/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include VERSION
+include requirements.txt
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         'Source': 'https://github.com/bsc-wdc/dislib',
         'Tracker': 'https://github.com/bsc-wdc/dislib/issues',
     },
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
# Description

When creating tar.gz file for distribution the files requirements.txt, VERSION and README.md were not included so the installation from sources failed.
