### PR TITLE
Improve release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ framework of the ERDF Operative Programme for Catalunya 2014-2020.
   - H2020 PerMedCoE  Center of Excellence (Contract 951773)
   - Horizon Europe CAELESTIS project (Contract 101056886)
   - Horizon Europe DT-Geo project (Contract 101058129)
+  - Horizon Europe CyclOps project (Contract 101135513)
 
 ## License
 

--- a/dislib/eddl/encapsulate_function_distributed.py
+++ b/dislib/eddl/encapsulate_function_distributed.py
@@ -19,8 +19,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
     - Synchronous training: At the end of each epoch, the weights are
       synchronized and the update is computed.
     - Partially asynchronous: The weights of each worker are updated
-      commutatively with the general weights and viceversa.
-    - Asynchronous training: A synchronization and update of the weigths is
+      commutatively with the general weights and vice versa.
+    - Asynchronous training: A synchronization and update of the weights is
       done after executing all the epochs or each n specified epochs.
 
     Attributes
@@ -29,8 +29,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
         weights and biases of the different layers of the network that
         is being trained.
     compss_object: list
-        List that contains objects of type PytorchDistributed, each of the
-        objects in this list makes a small part of the epoch training in
+        List that contains objects of type EddlDistributedConmutativo, each of
+        the objects in this list makes a small part of the epoch training in
         parallel to the rest.
     num_workers: int
         Number of parallel trainings existing.
@@ -41,9 +41,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
 
     def build(self, net, optimizer, loss, metric, num_gpu=0, num_nodes=0):
         """
-        Builds the model to obtain the initial parameters of the training
-        and it also builds the model in each worker
-        in order to be ready to start the training.
+        Builds the model to obtain the initial training parameters and
+        prepares a copy in each worker, ready to start the training.
 
         Parameters
         ----------
@@ -120,8 +119,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                                         num_epochs,
                                                         n_epocs_sync=1):
         """
-        Training of the neural network performing a syncrhonization every n
-        specified epochs, it performs a total shuffle of the dataset used.
+        Training of the neural network performing a synchronization every n
+        specified epochs, performing a total shuffle of the dataset.
 
         Parameters
         ----------
@@ -135,7 +134,7 @@ class EncapsulatedFunctionsDistributedEddl(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing a syncrhonization
+            Number of epochs to train before performing a synchronization
             and between synchronizations
         Returns
         -------
@@ -180,9 +179,9 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                                 shuffle_blocks=True,
                                                 shuffle_block_data=True):
         """
-        Training of the neural network performing a syncrhonization every
-        n specified epochs, it performs a total shuffle of the tensors on
-        the ds_tensor and the elements inside each tensor
+        Training of the neural network performing a synchronization every
+        n specified epochs, shuffling the tensors of the ds_tensor and the
+        elements inside each tensor
 
         Parameters
         ----------
@@ -196,7 +195,7 @@ class EncapsulatedFunctionsDistributedEddl(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing a syncrhonization
+            Number of epochs to train before performing a synchronization
             and between synchronizations
         shuffle_blocks: boolean
             Variable specifying to shuffle the blocks of the ds_tensor or not
@@ -247,9 +246,9 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                  num_epochs, shuffle_blocks=True,
                                  shuffle_block_data=True):
         """
-        Training of the neural network performing a syncrhonization of
-        the weights at the end of each epoch, it performs a total shuffle
-        of the tensors on the ds_tensor and the elements inside each tensor
+        Training of the neural network performing a synchronization of
+        the weights at the end of each epoch, shuffling the tensors of the
+        ds_tensor and the elements inside each tensor
 
         Parameters
         ----------
@@ -306,8 +305,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                          num_batches_per_worker,
                                          num_epochs):
         """
-        Training of the neural network performing a syncrhonization of
-        the weights every epoch, it performs a total shuffle of the dataset
+        Training of the neural network performing a synchronization of
+        the weights every epoch, performing a total shuffle of the dataset
 
         Parameters
         ----------
@@ -359,10 +358,9 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                   shuffle_blocks=True,
                                   shuffle_block_data=True):
         """
-        Training of the neural network performing an asyncrhonous update of
-        the weights every epoch,
-        it performs a shuffle of the tensors on the ds_tensor and a local
-        shuffle of the elements inside each tensor
+        Training of the neural network performing an asynchronous update of
+        the weights every epoch, shuffling the tensors of the ds_tensor and
+        locally shuffling the elements inside each tensor
 
         Parameters
         ----------
@@ -417,9 +415,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                           num_batches_per_worker,
                                           num_epochs):
         """
-        Training of the neural network performing an asyncrhonous update of
-        the weights every epoch,
-        it performs a total shuffle of the dataset
+        Training of the neural network performing an asynchronous update of
+        the weights every epoch, performing a total shuffle of the dataset
 
         Parameters
         ----------
@@ -471,10 +468,9 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                            shuffle_blocks=True,
                                            shuffle_block_data=True):
         """
-        Training of the neural network performing an asyncrhonous update of
-        the weights every n epochs,
-        it performs a shuffle of the tensors and locally a shuffle of the
-        elements inside each tensor
+        Training of the neural network performing an asynchronous update of
+        the weights every n epochs, shuffling the tensors and locally
+        shuffling the elements inside each tensor
 
         Parameters
         ----------
@@ -488,7 +484,7 @@ class EncapsulatedFunctionsDistributedEddl(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing an asyncrhonous
+            Number of epochs to train before performing an asynchronous
             update of the weights and between the following updates
         shuffle_blocks: boolean
             Variable specifying to shuffle the blocks of the ds_tensor or not
@@ -537,9 +533,8 @@ class EncapsulatedFunctionsDistributedEddl(object):
                                                    num_epochs,
                                                    n_epocs_sync=0):
         """
-        Training of the neural network performing an asyncrhonous update of
-        the weights every n epochs,
-        it performs a total shuffle of the dataset
+        Training of the neural network performing an asynchronous update of
+        the weights every n epochs, performing a total shuffle of the dataset
 
         Parameters
         ----------
@@ -553,7 +548,7 @@ class EncapsulatedFunctionsDistributedEddl(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing an asyncrhonous
+            Number of epochs to train before performing an asynchronous
             update of the weights and between the following updates
         Returns
         -------

--- a/dislib/pytorch/encapsulated_functions_distributed.py
+++ b/dislib/pytorch/encapsulated_functions_distributed.py
@@ -62,8 +62,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
     - Synchronous training: At the end of each epoch, the weights are
       synchronized and the update is computed.
     - Partially asynchronous: The weights of each worker are updated
-      commutatively with the general weights and viceversa.
-    - Asynchronous training: A synchronization and update of the weigths is
+      commutatively with the general weights and vice versa.
+    - Asynchronous training: A synchronization and update of the weights is
       done after executing all the epochs or each n specified epochs.
 
     Attributes
@@ -86,9 +86,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
     def build(self, net, optimizer, loss, optimizer_parameters,
               num_gpu=0, num_nodes=0):
         """
-        Builds the model to obtain the initial parameters of the training
-        and it also builds the model in each worker in order to be ready
-        to start the training.
+        Builds the model to obtain the initial training parameters and
+        prepares a copy in each worker, ready to start the training.
 
         Parameters
         ----------
@@ -133,8 +132,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                                         num_epochs,
                                                         n_epocs_sync=1):
         """
-        Training of the neural network performing a syncrhonization every n
-        specified epochs, it performs a total shuffle of the dataset used.
+        Training of the neural network performing a synchronization every n
+        specified epochs, performing a total shuffle of the dataset.
 
         Parameters
         ----------
@@ -148,7 +147,7 @@ class EncapsulatedFunctionsDistributedPytorch(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing a syncrhonization and
+            Number of epochs to train before performing a synchronization and
             between synchronizations
         Returns
         -------
@@ -193,9 +192,9 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                                 shuffle_blocks=True,
                                                 shuffle_block_data=True):
         """
-        Training of the neural network performing a syncrhonization every n
-        specified epochs,  it performs a total shuffle of the tensors on the
-        ds_tensor and the elements inside each tensor
+        Training of the neural network performing a synchronization every n
+        specified epochs, shuffling the tensors of the ds_tensor and the
+        elements inside each tensor
 
         Parameters
         ----------
@@ -209,7 +208,7 @@ class EncapsulatedFunctionsDistributedPytorch(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing a syncrhonization
+            Number of epochs to train before performing a synchronization
             and between synchronizations
         shuffle_blocks: boolean
             Variable specifying to shuffle the blocks of the ds_tensor or not
@@ -260,9 +259,9 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                  shuffle_blocks=True,
                                  shuffle_block_data=True):
         """
-        Training of the neural network performing a syncrhonization of the
-        weights at the end of each epoch, it performs a total shuffle of
-        the tensors on the ds_tensor and the elements inside each tensor
+        Training of the neural network performing a synchronization of the
+        weights at the end of each epoch, shuffling the tensors of the
+        ds_tensor and the elements inside each tensor
 
         Parameters
         ----------
@@ -319,8 +318,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                          num_batches_per_worker,
                                          num_epochs):
         """
-        Training of the neural network performing a syncrhonization of
-        the weights every epoch, it performs a total shuffle of the dataset
+        Training of the neural network performing a synchronization of
+        the weights every epoch, performing a total shuffle of the dataset
 
         Parameters
         ----------
@@ -371,10 +370,9 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                   shuffle_blocks=True,
                                   shuffle_block_data=True):
         """
-        Training of the neural network performing an asyncrhonous update
-        of the weights every epoch, it performs a shuffle of the tensors
-        on the ds_tensor and a local shuffle of the elements inside each
-        tensor
+        Training of the neural network performing an asynchronous update
+        of the weights every epoch, shuffling the tensors of the ds_tensor
+        and locally shuffling the elements inside each tensor
 
         Parameters
         ----------
@@ -430,9 +428,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                           num_batches_per_worker,
                                           num_epochs):
         """
-        Training of the neural network performing an asyncrhonous
-        update of the weights every epoch, it performs a total shuffle
-        of the dataset
+        Training of the neural network performing an asynchronous update
+        of the weights every epoch, performing a total shuffle of the dataset
 
         Parameters
         ----------
@@ -484,9 +481,9 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                            shuffle_blocks=True,
                                            shuffle_block_data=True):
         """
-        Training of the neural network performing an asyncrhonous update
-        of the weights every n epochs, it performs a shuffle of the tensors
-        and locally a shuffle of the elements inside each tensor
+        Training of the neural network performing an asynchronous update
+        of the weights every n epochs, shuffling the tensors and locally
+        shuffling the elements inside each tensor
 
         Parameters
         ----------
@@ -500,7 +497,7 @@ class EncapsulatedFunctionsDistributedPytorch(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing an asyncrhonous
+            Number of epochs to train before performing an asynchronous
             update of the weights and between the following updates
         shuffle_blocks: boolean
             Variable specifying to shuffle the blocks of the ds_tensor or not
@@ -548,8 +545,8 @@ class EncapsulatedFunctionsDistributedPytorch(object):
                                                    num_epochs,
                                                    n_epocs_sync=0):
         """
-        Training of the neural network performing an asyncrhonous update
-        of the weights every n epochs, it performs a total shuffle of the
+        Training of the neural network performing an asynchronous update
+        of the weights every n epochs, performing a total shuffle of the
         dataset
 
         Parameters
@@ -564,7 +561,7 @@ class EncapsulatedFunctionsDistributedPytorch(object):
         num_epochs: int
             Total number of epochs to train the model
         n_epocs_sync: int
-            Number of epochs to train before performing an asyncrhonous update
+            Number of epochs to train before performing an asynchronous update
             of the weights and between the following updates
         Returns
         -------

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -9,10 +9,11 @@ if [[ "$1" == "--versioned" ]]; then
     VERSION=$(cat "$ROOT_DIR/VERSION")
 fi
 
-docker login -u "${dh_username}" -p "${dh_password}"
 docker push bscwdc/dislib:latest
 docker push bscwdc/dislib:torch
 if $VERSIONED; then
-    docker push bscwdc/dislib:${VERSION}
-    docker push bscwdc/dislib:${VERSION}-torch
+    docker tag bscwdc/dislib:latest bscwdc/dislib:v${VERSION}
+    docker tag bscwdc/dislib:torch bscwdc/dislib:v${VERSION}-torch
+    docker push bscwdc/dislib:v${VERSION}
+    docker push bscwdc/dislib:v${VERSION}-torch
 fi

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ['pycompss', 'pyeddl', 'eddl']
+autodoc_mock_imports = ['pycompss', 'pyeddl', 'eddl', 'torch']
 
 autodoc_default_options = {
     'exclude-members': (

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -64,16 +64,27 @@ Follow these steps when drafting a new release:
 
 12. Create a pip package and upload it to PyPi:
 
-    - Ensure that you have the latest version of ``setuptools``,
+    - Ensure that you have the latest version of
       ``wheel``, and ``twine`` installed:
 
       .. code:: bash
 
-        pip3 install --upgrade setuptools wheel twine
+        pip3 install --upgrade build twine
+
+    - Build the package:
+
+      .. code:: bash
+
+       python3 -m build
+
+    - Validate befoe uploading:
+
+      .. code:: bash
+
+       twine check dist/*
 
     - Create and upload the pip package:
 
       .. code:: bash
 
-       python3 setup.py sdist bdist_wheel
        python3 -m twine upload dist/dislib-X.Y.Z*

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -42,25 +42,22 @@ Follow these steps when drafting a new release:
     .com/bsc-wdc/dislib/blob/master/.github/RELEASE_TEMPLATE.md>`_ using tag
     name ``vX.Y.Z``.
 
-11. Create and tag a docker image for the release running the following at the
-    repo's root:
+11. Create and tag docker images for the release using the scripts under
+    ``docker/``:
 
-    - Create the image:
-     
+    - Build the base, torch, and CI images (tagged with the version from the
+      ``VERSION`` file and as ``latest``):
+
       .. code:: bash
-     
-       docker build -t bscwdc/dislib:vX.Y.Z .
-       
-       # Create also new 'latest' tag using newly created image
-       docker tag bscwdc/dislib:vX.Y.Z bscwdc/dislib:latest
-   
-    - Log in and push it to dockerhub
-   
+
+       ./docker/build.sh --versioned
+
+    - Log in and push all images to dockerhub:
+
       .. code:: bash
 
        docker login -u DOCKERHUB_USER -p DOCKERHUB_PASSWORD
-       docker push bscwdc/dislib:vX.Y.Z
-       docker push bscwdc/dislib:latest
+       ./docker/push.sh --versioned
 
 12. Create a pip package and upload it to PyPi:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ scikit-learn>=1.7
 scipy>=1.13
 numpy>=2.0
 cvxpy>=1.4.2
-cbor2>=5.4.0
+cbor2>=5.4.0,<6.0.0
 pyarrow>=16.0.0


### PR DESCRIPTION
# Description

- Improve instructions for PyPI release and docker retag to upload images to dockerhub.
- Fix documentation issue: torch and eddl API pages didn't show on readthedocs
- Pin version for cbor2 breaking changes in newest v6.0.0

## Type of change

Documentation and minor CD commands.
